### PR TITLE
feat(cli): support AWS Secret Manager as a keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+env.sh

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,9 @@ base64 = "0.22.1"
 bs58 = "0.5.1"
 sha3 = "0.10"
 color-eyre = "0.6.3"
+aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-sdk-secretsmanager = "1.40.0"
+tokio = { version = "1", features = ["full"] }
 
 [[bin]]
 name = "karak"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced keypair management enhancements in the CLI application, allowing selection between local and AWS keystores.
  - Added support for managing secrets in AWS Secrets Manager with improved error handling.

- **Chores**
  - Updated the `.gitignore` file to enhance project security by excluding sensitive configuration files.
  - Added new dependencies for improved AWS service integration and asynchronous processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->