### PR TITLE
chore: downgrade `thiserror`

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ karak-sdk = { path = "../sdk" }
 rand = "0.8.5"
 rpassword = "7.3"
 sha3 = "0.10"
-thiserror = "1.0.63"
+thiserror = "1.0.62"
 tokio = { workspace = true }
 url = "2.5.2"
 # TODO: Update to latest versions of these

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -22,7 +22,7 @@ scrypt = "0.10"
 hex = "0.4"
 sha3 = "0.10"
 bs58 = "0.5.1"
-thiserror = "1.0.63"
+thiserror = "1.0.62"
 bincode = "1.3.3"
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-secretsmanager = "1.40.0"
@@ -31,4 +31,3 @@ alloy-sol-types = "0.7.7"
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["node-bindings"] }
-


### PR DESCRIPTION
We need to match reth's version of thiserror so we don't get dependency conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Downgraded the `thiserror` dependency, which may enhance stability in error handling.
  
- **Chores**
	- Minor formatting adjustment in `sdk` dependency file for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->