### PR TITLE
[ADL-3359] feat: add error decoding/conversion for contract reverts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
  "signature",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
  "alloy-provider",
@@ -148,7 +149,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -255,7 +256,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -277,7 +278,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -304,7 +305,7 @@ dependencies = [
  "rand",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "url",
 ]
@@ -370,7 +371,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "url",
@@ -414,7 +415,7 @@ checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -521,7 +522,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -538,7 +539,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -557,7 +558,7 @@ dependencies = [
  "eth-keystore",
  "k256",
  "rand",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -571,7 +572,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -588,7 +589,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -606,7 +607,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.87",
  "syn-solidity",
 ]
 
@@ -645,7 +646,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tower 0.5.1",
  "tracing",
@@ -960,7 +961,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.63",
  "time",
 ]
 
@@ -972,7 +973,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -984,7 +985,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1036,7 +1037,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1047,7 +1048,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1093,7 +1094,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1749,7 +1750,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1934,7 +1935,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2038,7 +2039,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "unicode-xid",
 ]
 
@@ -2051,7 +2052,7 @@ dependencies = [
  "console",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "zeroize",
 ]
 
@@ -2105,7 +2106,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2205,7 +2206,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2242,7 +2243,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "thiserror",
+ "thiserror 1.0.63",
  "uuid 0.8.2",
 ]
 
@@ -2435,7 +2436,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2653,7 +2654,7 @@ dependencies = [
  "once_cell",
  "rand",
  "socket2",
- "thiserror",
+ "thiserror 1.0.63",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2676,7 +2677,7 @@ dependencies = [
  "rand",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
 ]
@@ -3122,6 +3123,7 @@ dependencies = [
  "eyre",
  "serde",
  "serde_json",
+ "thiserror 2.0.3",
  "tokio",
  "trait-variant",
 ]
@@ -3154,7 +3156,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "signature",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "trait-variant",
  "url",
@@ -3167,7 +3169,7 @@ dependencies = [
  "async-trait",
  "futures",
  "libp2p",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3248,7 +3250,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -3296,7 +3298,7 @@ dependencies = [
  "rand",
  "rw-stream-sink",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "unsigned-varint 0.8.0",
  "void",
@@ -3363,7 +3365,7 @@ dependencies = [
  "quick-protobuf",
  "rand",
  "sha2",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "zeroize",
 ]
@@ -3390,7 +3392,7 @@ dependencies = [
  "rand",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "uint",
  "void",
@@ -3455,7 +3457,7 @@ dependencies = [
  "sha2",
  "snow",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -3480,7 +3482,7 @@ dependencies = [
  "ring 0.17.8",
  "rustls 0.23.13",
  "socket2",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
 ]
@@ -3518,7 +3520,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3552,7 +3554,7 @@ dependencies = [
  "ring 0.17.8",
  "rustls 0.23.13",
  "rustls-webpki 0.101.7",
- "thiserror",
+ "thiserror 1.0.63",
  "x509-parser",
  "yasna",
 ]
@@ -3582,7 +3584,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.3",
@@ -3804,7 +3806,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "paste",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -3818,7 +3820,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
 ]
 
@@ -3934,7 +3936,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3990,7 +3992,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4143,7 +4145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.63",
  "ucd-trie",
 ]
 
@@ -4174,7 +4176,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4297,7 +4299,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4329,7 +4331,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4376,7 +4378,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror",
+ "thiserror 1.0.63",
  "unsigned-varint 0.8.0",
 ]
 
@@ -4394,7 +4396,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.13",
  "socket2",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
 ]
@@ -4411,7 +4413,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.13",
  "slab",
- "thiserror",
+ "thiserror 1.0.63",
  "tinyvec",
  "tracing",
 ]
@@ -4520,7 +4522,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -4694,7 +4696,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "nix",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
 ]
 
@@ -5057,7 +5059,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5274,7 +5276,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5296,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5314,7 +5316,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5340,7 +5342,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5389,7 +5391,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -5400,7 +5411,18 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5503,7 +5525,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5655,7 +5677,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5715,7 +5737,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5740,7 +5762,7 @@ dependencies = [
  "rustls 0.23.13",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 1.0.63",
  "utf-8",
 ]
 
@@ -5969,7 +5991,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -6003,7 +6025,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6300,7 +6322,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror",
+ "thiserror 1.0.63",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6340,7 +6362,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.63",
  "time",
 ]
 
@@ -6423,7 +6445,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6443,5 +6465,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]

--- a/crates/cli/src/operator/processor/erc20.rs
+++ b/crates/cli/src/operator/processor/erc20.rs
@@ -15,9 +15,11 @@ pub async fn mint<T: Transport + Clone, P: Provider<T>>(
     let receipt = erc20_instance
         .mint(operator_address, amount)
         .send()
-        .await?
+        .await
+        .map_err(karak_contracts::erc20::mintable::Error::from)?
         .get_receipt()
-        .await?;
+        .await
+        .map_err(karak_contracts::erc20::mintable::Error::from)?;
 
     println!(
         "Minted {} {} to {} in tx {}",

--- a/crates/cli/src/operator/processor/erc20.rs
+++ b/crates/cli/src/operator/processor/erc20.rs
@@ -4,7 +4,7 @@ use alloy::{
     transports::Transport,
 };
 use eyre::Result;
-use karak_contracts::erc20::mintable::ERC20Mintable::ERC20MintableInstance;
+use karak_contracts::erc20::mintable::{ERC20Mintable::ERC20MintableInstance, ERC20MintableError};
 
 pub async fn mint<T: Transport + Clone, P: Provider<T>>(
     amount: U256,
@@ -16,10 +16,10 @@ pub async fn mint<T: Transport + Clone, P: Provider<T>>(
         .mint(operator_address, amount)
         .send()
         .await
-        .map_err(karak_contracts::erc20::mintable::Error::from)?
+        .map_err(ERC20MintableError::from)?
         .get_receipt()
         .await
-        .map_err(karak_contracts::erc20::mintable::Error::from)?;
+        .map_err(ERC20MintableError::from)?;
 
     println!(
         "Minted {} {} to {} in tx {}",

--- a/crates/cli/src/operator/processor/mod.rs
+++ b/crates/cli/src/operator/processor/mod.rs
@@ -15,9 +15,12 @@ use alloy::{
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_secretsmanager::config::{Credentials, SharedCredentialsProvider};
 use karak_contracts::{
-    erc20::mintable::ERC20Mintable, registry::RestakingRegistry, vault::Vault::VaultInstance,
-    Core::CoreInstance,
+    erc20::contract::ERC20::ERC20Instance, registry::RestakingRegistry,
+    vault::Vault::VaultInstance, Core::CoreInstance,
 };
+
+#[cfg(feature = "testnet")]
+use karak_contracts::erc20::mintable::ERC20Mintable::ERC20MintableInstance;
 
 use crate::config::models::{Curve, Keystore, Profile};
 use crate::prompter;
@@ -287,7 +290,7 @@ pub async fn process(
             };
             let vault_instance = VaultInstance::new(vault_address, provider.clone());
             let asset_address = vault_instance.asset().call().await?._0;
-            let erc20_instance = ERC20Mintable::new(asset_address, provider.clone());
+            let erc20_instance = ERC20Instance::new(asset_address, provider.clone());
 
             vault::deposit_to_vault(
                 amount,
@@ -312,7 +315,7 @@ pub async fn process(
                 None => prompter::input::<U256>("Enter amount", None, None)?,
             };
 
-            let erc20_instance = ERC20Mintable::new(asset_address, provider);
+            let erc20_instance = ERC20MintableInstance::new(asset_address, provider);
             erc20::mint(amount, operator_address, erc20_instance).await?
         }
     }

--- a/crates/cli/src/operator/processor/stake.rs
+++ b/crates/cli/src/operator/processor/stake.rs
@@ -6,7 +6,10 @@ use alloy::{
 use clap::ValueEnum;
 use eyre::Result;
 use karak_contracts::{
-    core::contract::Operator::{QueuedStakeUpdate, StakeUpdateRequest},
+    core::contract::{
+        CoreError,
+        Operator::{QueuedStakeUpdate, StakeUpdateRequest},
+    },
     Core::{self, CoreInstance},
 };
 use strum_macros::{Display, EnumString, FromRepr, VariantNames};
@@ -42,10 +45,10 @@ pub async fn process_stake_update_request<T: Transport + Clone, P: Provider<T>>(
         .requestUpdateVaultStakeInDSS(stake_update_request)
         .send()
         .await
-        .map_err(karak_contracts::core::contract::Error::from)?
+        .map_err(CoreError::from)?
         .get_receipt()
         .await
-        .map_err(karak_contracts::core::contract::Error::from)?;
+        .map_err(CoreError::from)?;
 
     println!("Requested stake update in tx {}", receipt.transaction_hash);
 
@@ -86,10 +89,10 @@ pub async fn process_finalize_stake_update_request<T: Transport + Clone, P: Prov
         .finalizeUpdateVaultStakeInDSS(queued_stake_update)
         .send()
         .await
-        .map_err(karak_contracts::core::contract::Error::from)?
+        .map_err(CoreError::from)?
         .get_receipt()
         .await
-        .map_err(karak_contracts::core::contract::Error::from)?;
+        .map_err(CoreError::from)?;
 
     println!("Finalized stake update in tx {}", receipt.transaction_hash);
 

--- a/crates/cli/src/operator/processor/stake.rs
+++ b/crates/cli/src/operator/processor/stake.rs
@@ -41,9 +41,11 @@ pub async fn process_stake_update_request<T: Transport + Clone, P: Provider<T>>(
     let receipt = core_instance
         .requestUpdateVaultStakeInDSS(stake_update_request)
         .send()
-        .await?
+        .await
+        .map_err(karak_contracts::core::contract::Error::from)?
         .get_receipt()
-        .await?;
+        .await
+        .map_err(karak_contracts::core::contract::Error::from)?;
 
     println!("Requested stake update in tx {}", receipt.transaction_hash);
 
@@ -83,9 +85,11 @@ pub async fn process_finalize_stake_update_request<T: Transport + Clone, P: Prov
     let receipt = core_instance
         .finalizeUpdateVaultStakeInDSS(queued_stake_update)
         .send()
-        .await?
+        .await
+        .map_err(karak_contracts::core::contract::Error::from)?
         .get_receipt()
-        .await?;
+        .await
+        .map_err(karak_contracts::core::contract::Error::from)?;
 
     println!("Finalized stake update in tx {}", receipt.transaction_hash);
 

--- a/crates/cli/src/operator/processor/vault.rs
+++ b/crates/cli/src/operator/processor/vault.rs
@@ -247,9 +247,11 @@ pub async fn process_vault_creation<T: Transport + Clone, P: Provider<T> + Clone
     let receipt = core_instance
         .deployVaults(vault_configs, vault_impl)
         .send()
-        .await?
+        .await
+        .map_err(karak_contracts::core::contract::Error::from)?
         .get_receipt()
-        .await?;
+        .await
+        .map_err(karak_contracts::core::contract::Error::from)?;
 
     let asset_map = assets
         .into_iter()
@@ -281,9 +283,11 @@ pub async fn deposit_to_vault<T: Transport + Clone, P: Provider<T>>(
     let receipt = erc20_instance
         .approve(vault_address, amount)
         .send()
-        .await?
+        .await
+        .map_err(karak_contracts::erc20::mintable::Error::from)?
         .get_receipt()
-        .await?;
+        .await
+        .map_err(karak_contracts::erc20::mintable::Error::from)?;
 
     println!(
         "Approved spending {} {} in tx {}",
@@ -293,9 +297,11 @@ pub async fn deposit_to_vault<T: Transport + Clone, P: Provider<T>>(
     let receipt = vault_instance
         .deposit_0(amount, operator_address)
         .send()
-        .await?
+        .await
+        .map_err(karak_contracts::vault::Error::from)?
         .get_receipt()
-        .await?;
+        .await
+        .map_err(karak_contracts::vault::Error::from)?;
 
     println!(
         "Deposited {} {} to vault {} in tx {}",

--- a/crates/cli/src/operator/processor/vault.rs
+++ b/crates/cli/src/operator/processor/vault.rs
@@ -10,7 +10,7 @@ use alloy::{
 };
 use eyre::{eyre, Result};
 use karak_contracts::{
-    core::contract::VaultLib,
+    core::contract::{CoreError, VaultLib},
     erc20::{
         contract::{ERC20Error, ERC20::ERC20Instance},
         interface::IERC20Metadata::IERC20MetadataInstance,
@@ -251,10 +251,10 @@ pub async fn process_vault_creation<T: Transport + Clone, P: Provider<T> + Clone
         .deployVaults(vault_configs, vault_impl)
         .send()
         .await
-        .map_err(VaultError::from)?
+        .map_err(CoreError::from)?
         .get_receipt()
         .await
-        .map_err(VaultError::from)?;
+        .map_err(CoreError::from)?;
 
     let asset_map = assets
         .into_iter()

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -8,9 +8,10 @@ repository = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-alloy = { workspace = true }
+alloy = { workspace = true, features = ["json-rpc", "rpc"] }
 eyre = "0.6.12"
 serde.workspace = true
+thiserror = "2.0.3"
 trait-variant = { workspace = true }
 
 [dev-dependencies]

--- a/crates/contracts/abi/ERC20.json
+++ b/crates/contracts/abi/ERC20.json
@@ -1,0 +1,310 @@
+[
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientAllowance",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "allowance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientBalance",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSpender",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+]

--- a/crates/contracts/abi/IERC20Metadata.json
+++ b/crates/contracts/abi/IERC20Metadata.json
@@ -1,0 +1,224 @@
+[
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/crates/contracts/abi/Operator.json
+++ b/crates/contracts/abi/Operator.json
@@ -1,0 +1,100 @@
+[
+  {
+    "type": "event",
+    "name": "HookCallFailed",
+    "inputs": [
+      {
+        "name": "returnData",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "HookCallSucceeded",
+    "inputs": [
+      {
+        "name": "returnData",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InterfaceNotSupported",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AllVaultsNotUnstakedFromDSS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DSSHookCallReverted",
+    "inputs": [
+      {
+        "name": "revertReason",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidQueuedStakeUpdateInput",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxDSSCapacityReached",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotEnoughGas",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OperatorAlreadyRegisteredToDSS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OperatorNotValidatingForDSS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OperatorStakeUpdateDelayNotPassed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PendingStakeUpdateRequest",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "VaultAlreadyStakedInDSS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "VaultNotAChildVault",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "VaultNotStakedInDSS",
+    "inputs": []
+  }
+]

--- a/crates/contracts/abi/SafeTransferLib.json
+++ b/crates/contracts/abi/SafeTransferLib.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "error",
+    "name": "ApproveFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ETHTransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Permit2AmountOverflow",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Permit2Failed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFromFailed",
+    "inputs": []
+  }
+]

--- a/crates/contracts/src/core/contract.rs
+++ b/crates/contracts/src/core/contract.rs
@@ -150,24 +150,24 @@ impl Display for Core::CoreErrors {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error<E: std::fmt::Debug> {
+pub enum CoreError<E: std::fmt::Debug> {
     #[error("Core error: {0}")]
-    CoreError(Core::CoreErrors),
+    Revert(Core::CoreErrors),
     #[error(transparent)]
     Inner(E),
 }
 
-impl<E: std::fmt::Debug> From<Core::CoreErrors> for Error<E> {
+impl<E: std::fmt::Debug> From<Core::CoreErrors> for CoreError<E> {
     fn from(error: Core::CoreErrors) -> Self {
-        Error::CoreError(error)
+        CoreError::Revert(error)
     }
 }
 
-impl From<ErrorPayload> for Error<ErrorPayload> {
+impl From<ErrorPayload> for CoreError<ErrorPayload> {
     fn from(value: ErrorPayload) -> Self {
         match value.as_decoded_error::<Core::CoreErrors>(true) {
-            Some(error) => Error::CoreError(error),
-            None => Error::Inner(value),
+            Some(error) => CoreError::Revert(error),
+            None => CoreError::Inner(value),
         }
     }
 }
@@ -181,11 +181,11 @@ impl DecodeError<Core::CoreErrors> for TransportError {
     }
 }
 
-impl From<TransportError> for Error<TransportError> {
+impl From<TransportError> for CoreError<TransportError> {
     fn from(value: TransportError) -> Self {
         match value.decode_error() {
-            Some(error) => Error::CoreError(error),
-            _ => Error::Inner(value),
+            Some(error) => CoreError::Revert(error),
+            _ => CoreError::Inner(value),
         }
     }
 }
@@ -201,11 +201,11 @@ impl DecodeError<Core::CoreErrors> for alloy::contract::Error {
     }
 }
 
-impl From<alloy::contract::Error> for Error<alloy::contract::Error> {
+impl From<alloy::contract::Error> for CoreError<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
         match value.decode_error() {
-            Some(error) => Error::CoreError(error),
-            _ => Error::Inner(value),
+            Some(error) => CoreError::Revert(error),
+            _ => CoreError::Inner(value),
         }
     }
 }
@@ -221,11 +221,11 @@ impl DecodeError<Core::CoreErrors> for PendingTransactionError {
     }
 }
 
-impl From<PendingTransactionError> for Error<PendingTransactionError> {
+impl From<PendingTransactionError> for CoreError<PendingTransactionError> {
     fn from(value: PendingTransactionError) -> Self {
         match value.decode_error() {
-            Some(error) => Error::CoreError(error),
-            _ => Error::Inner(value),
+            Some(error) => CoreError::Revert(error),
+            _ => CoreError::Inner(value),
         }
     }
 }

--- a/crates/contracts/src/core/contract.rs
+++ b/crates/contracts/src/core/contract.rs
@@ -1,7 +1,16 @@
-use alloy::sol;
+use std::fmt::{Debug, Display};
+
+use alloy::{
+    providers::PendingTransactionError,
+    rpc::json_rpc::ErrorPayload,
+    sol,
+    transports::{RpcError, TransportError},
+};
 use serde::{ser::SerializeStruct, Serialize};
 use Operator::{QueuedStakeUpdate, StakeUpdateRequest};
 use VaultLib::Config;
+
+use crate::error::DecodeError;
 
 sol!(
     #[allow(missing_docs)]
@@ -9,6 +18,217 @@ sol!(
     Core,
     "abi/Core.json",
 );
+
+impl std::fmt::Debug for Core::CoreErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Core::CoreErrors::AlreadyInitialized(_) => write!(f, "AlreadyInitialized"),
+            Core::CoreErrors::AssetNotAllowlisted(_) => write!(f, "AssetNotAllowlisted"),
+            Core::CoreErrors::AttemptedPauseWhileUnpausing(_) => {
+                write!(f, "AttemptedPauseWhileUnpausing")
+            }
+            Core::CoreErrors::AttemptedUnpauseWhilePausing(_) => {
+                write!(f, "AttemptedUnpauseWhilePausing")
+            }
+            Core::CoreErrors::DSSAlreadyRegistered(_) => write!(f, "DSSAlreadyRegistered"),
+            Core::CoreErrors::DSSHookCallReverted(_) => write!(f, "DSSHookCallReverted"),
+            Core::CoreErrors::DSSNotRegistered(_) => write!(f, "DSSNotRegistered"),
+            Core::CoreErrors::DuplicateSlashingVaults(_) => write!(f, "DuplicateSlashingVaults"),
+            Core::CoreErrors::EmptyArray(_) => write!(f, "EmptyArray"),
+            Core::CoreErrors::EnforcedPause(_) => write!(f, "EnforcedPause"),
+            Core::CoreErrors::EnforcedPauseFunction(_) => write!(f, "EnforcedPauseFunction"),
+            Core::CoreErrors::InvalidInitialization(_) => write!(f, "InvalidInitialization"),
+            Core::CoreErrors::InvalidSlashingCount(_) => write!(f, "InvalidSlashingCount"),
+            Core::CoreErrors::InvalidSlashingParams(_) => write!(f, "InvalidSlashingParams"),
+            Core::CoreErrors::LengthsDontMatch(_) => write!(f, "LengthsDontMatch"),
+            Core::CoreErrors::MathOverflowedMulDiv(_) => write!(f, "MathOverflowedMulDiv"),
+            Core::CoreErrors::MaxSlashPercentageWadBreached(_) => {
+                write!(f, "MaxSlashPercentageWadBreached")
+            }
+            Core::CoreErrors::MaxSlashableVaultsPerRequestBreached(_) => {
+                write!(f, "MaxSlashableVaultsPerRequestBreached")
+            }
+            Core::CoreErrors::MaxVaultCapacityReached(_) => write!(f, "MaxVaultCapacityReached"),
+            Core::CoreErrors::MinSlashingDelayNotPassed(_) => {
+                write!(f, "MinSlashingDelayNotPassed")
+            }
+            Core::CoreErrors::NewOwnerIsZeroAddress(_) => write!(f, "NewOwnerIsZeroAddress"),
+            Core::CoreErrors::NoHandoverRequest(_) => write!(f, "NoHandoverRequest"),
+            Core::CoreErrors::NotEnoughGas(_) => write!(f, "NotEnoughGas"),
+            Core::CoreErrors::NotInitializing(_) => write!(f, "NotInitializing"),
+            Core::CoreErrors::NotSmartContract(_) => write!(f, "NotSmartContract"),
+            Core::CoreErrors::OperatorNotValidatingForDSS(_) => {
+                write!(f, "OperatorNotValidatingForDSS")
+            }
+            Core::CoreErrors::Reentrancy(_) => write!(f, "Reentrancy"),
+            Core::CoreErrors::ReservedAddress(_) => write!(f, "ReservedAddress"),
+            Core::CoreErrors::SlashingCooldownNotPassed(_) => {
+                write!(f, "SlashingCooldownNotPassed")
+            }
+            Core::CoreErrors::Unauthorized(_) => write!(f, "Unauthorized"),
+            Core::CoreErrors::VaultCreationFailedAddrMismatch(mismatch) => {
+                write!(
+                    f,
+                    "VaultCreationFailedAddrMismatch {{ expected: {}, actual: {} }}",
+                    mismatch.expected, mismatch.actual
+                )
+            }
+            Core::CoreErrors::VaultImplNotAllowlisted(_) => write!(f, "VaultImplNotAllowlisted"),
+            Core::CoreErrors::VaultNotAChildVault(_) => write!(f, "VaultNotAChildVault"),
+            Core::CoreErrors::VaultNotStakedToDSS(_) => write!(f, "VaultNotStakedToDSS"),
+            Core::CoreErrors::ZeroAddress(_) => write!(f, "ZeroAddress"),
+            Core::CoreErrors::ZeroSlashPercentageWad(_) => write!(f, "ZeroSlashPercentageWad"),
+        }
+    }
+}
+
+impl Display for Core::CoreErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Core::CoreErrors::AlreadyInitialized(_) => write!(f, "Already initialized"),
+            Core::CoreErrors::AssetNotAllowlisted(_) => {
+                write!(f, "Asset not allowlisted")
+            }
+            Core::CoreErrors::AttemptedPauseWhileUnpausing(_) => {
+                write!(f, "Attempted pause while unpausing")
+            }
+            Core::CoreErrors::AttemptedUnpauseWhilePausing(_) => {
+                write!(f, "Attempted unpause while pausing")
+            }
+            Core::CoreErrors::DSSAlreadyRegistered(_) => write!(f, "DSS already registered"),
+            Core::CoreErrors::DSSHookCallReverted(e) => {
+                write!(f, "DSS hook call reverted with error: {}", e.revertReason)
+            }
+            Core::CoreErrors::DSSNotRegistered(_) => write!(f, "DSS not registered"),
+            Core::CoreErrors::DuplicateSlashingVaults(_) => write!(f, "Duplicate slashing vaults"),
+            Core::CoreErrors::EmptyArray(_) => write!(f, "Empty array"),
+            Core::CoreErrors::EnforcedPause(_) => write!(f, "Enforced pause"),
+            Core::CoreErrors::EnforcedPauseFunction(_) => write!(f, "Enforced pause function"),
+            Core::CoreErrors::InvalidInitialization(_) => write!(f, "Invalid initialization"),
+            Core::CoreErrors::InvalidSlashingCount(_) => write!(f, "Invalid slashing count"),
+            Core::CoreErrors::InvalidSlashingParams(_) => write!(f, "Invalid slashing params"),
+            Core::CoreErrors::LengthsDontMatch(_) => write!(f, "Lengths don't match"),
+            Core::CoreErrors::MathOverflowedMulDiv(_) => write!(f, "Math overflowed mul div"),
+            Core::CoreErrors::MaxSlashPercentageWadBreached(_) => {
+                write!(f, "Max slash percentage wad breached")
+            }
+            Core::CoreErrors::MaxSlashableVaultsPerRequestBreached(_) => {
+                write!(f, "Max slashable vaults per request breached")
+            }
+            Core::CoreErrors::MaxVaultCapacityReached(_) => write!(f, "Max vault capacity reached"),
+            Core::CoreErrors::MinSlashingDelayNotPassed(_) => {
+                write!(f, "Min slashing delay not passed")
+            }
+            Core::CoreErrors::NewOwnerIsZeroAddress(_) => write!(f, "New owner is zero address"),
+            Core::CoreErrors::NoHandoverRequest(_) => write!(f, "No handover request"),
+            Core::CoreErrors::NotEnoughGas(_) => write!(f, "Not enough gas"),
+            Core::CoreErrors::NotInitializing(_) => write!(f, "Not initializing"),
+            Core::CoreErrors::NotSmartContract(_) => write!(f, "Not smart contract"),
+            Core::CoreErrors::OperatorNotValidatingForDSS(_) => {
+                write!(f, "Operator not validating for DSS")
+            }
+            Core::CoreErrors::Reentrancy(_) => write!(f, "Reentrancy"),
+            Core::CoreErrors::ReservedAddress(_) => write!(f, "Reserved address"),
+            Core::CoreErrors::SlashingCooldownNotPassed(_) => {
+                write!(f, "Slashing cooldown not passed")
+            }
+            Core::CoreErrors::Unauthorized(_) => write!(f, "Unauthorized"),
+            Core::CoreErrors::VaultCreationFailedAddrMismatch(e) => {
+                write!(
+                    f,
+                    "Vault creation failed address mismatch, expected {}, got {}",
+                    e.expected, e.actual
+                )
+            }
+            Core::CoreErrors::VaultImplNotAllowlisted(_) => write!(f, "Vault impl not allowlisted"),
+            Core::CoreErrors::VaultNotAChildVault(_) => write!(f, "Vault not a child vault"),
+            Core::CoreErrors::VaultNotStakedToDSS(_) => write!(f, "Vault not staked to DSS"),
+            Core::CoreErrors::ZeroAddress(_) => write!(f, "Zero address"),
+            Core::CoreErrors::ZeroSlashPercentageWad(_) => write!(f, "Zero slash percentage wad"),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error<E: std::fmt::Debug> {
+    #[error("Core error: {0}")]
+    CoreError(Core::CoreErrors),
+    #[error(transparent)]
+    Inner(E),
+}
+
+impl<E: std::fmt::Debug> From<Core::CoreErrors> for Error<E> {
+    fn from(error: Core::CoreErrors) -> Self {
+        Error::CoreError(error)
+    }
+}
+
+impl From<ErrorPayload> for Error<ErrorPayload> {
+    fn from(value: ErrorPayload) -> Self {
+        match value.as_decoded_error::<Core::CoreErrors>(true) {
+            Some(error) => Error::CoreError(error),
+            None => Error::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<Core::CoreErrors> for TransportError {
+    fn decode_error(&self) -> Option<Core::CoreErrors> {
+        match self {
+            RpcError::ErrorResp(error) => error.as_decoded_error::<Core::CoreErrors>(true),
+            _ => None,
+        }
+    }
+}
+
+impl From<TransportError> for Error<TransportError> {
+    fn from(value: TransportError) -> Self {
+        match value.decode_error() {
+            Some(error) => Error::CoreError(error),
+            _ => Error::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<Core::CoreErrors> for alloy::contract::Error {
+    fn decode_error(&self) -> Option<Core::CoreErrors> {
+        match self {
+            alloy::contract::Error::TransportError(transport_error) => {
+                transport_error.decode_error()
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for Error<alloy::contract::Error> {
+    fn from(value: alloy::contract::Error) -> Self {
+        match value.decode_error() {
+            Some(error) => Error::CoreError(error),
+            _ => Error::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<Core::CoreErrors> for PendingTransactionError {
+    fn decode_error(&self) -> Option<Core::CoreErrors> {
+        match self {
+            PendingTransactionError::TransportError(transport_error) => {
+                transport_error.decode_error()
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<PendingTransactionError> for Error<PendingTransactionError> {
+    fn from(value: PendingTransactionError) -> Self {
+        match value.decode_error() {
+            Some(error) => Error::CoreError(error),
+            _ => Error::Inner(value),
+        }
+    }
+}
 
 impl Serialize for StakeUpdateRequest {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/contracts/src/core/library/mod.rs
+++ b/crates/contracts/src/core/library/mod.rs
@@ -1,0 +1,1 @@
+pub mod operator;

--- a/crates/contracts/src/core/library/operator.rs
+++ b/crates/contracts/src/core/library/operator.rs
@@ -1,0 +1,182 @@
+use alloy::{
+    providers::PendingTransactionError,
+    rpc::json_rpc::ErrorPayload,
+    sol,
+    transports::{RpcError, TransportError},
+};
+
+use crate::error::DecodeError;
+
+sol!(
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    Operator,
+    "abi/Operator.json",
+);
+
+impl std::fmt::Debug for Operator::OperatorErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Operator::OperatorErrors::AllVaultsNotUnstakedFromDSS(_) => {
+                write!(f, "AllVaultsNotUnstakedFromDSS")
+            }
+            Operator::OperatorErrors::DSSHookCallReverted(_) => {
+                write!(f, "DSSHookCallReverted")
+            }
+            Operator::OperatorErrors::InvalidQueuedStakeUpdateInput(_) => {
+                write!(f, "InvalidQueuedStakeUpdateInput")
+            }
+            Operator::OperatorErrors::MaxDSSCapacityReached(_) => {
+                write!(f, "MaxDSSCapacityReached")
+            }
+            Operator::OperatorErrors::NotEnoughGas(_) => {
+                write!(f, "NotEnoughGas")
+            }
+            Operator::OperatorErrors::OperatorAlreadyRegisteredToDSS(_) => {
+                write!(f, "OperatorAlreadyRegisteredToDSS")
+            }
+            Operator::OperatorErrors::OperatorNotValidatingForDSS(_) => {
+                write!(f, "OperatorNotValidatingForDSS")
+            }
+            Operator::OperatorErrors::OperatorStakeUpdateDelayNotPassed(_) => {
+                write!(f, "OperatorStakeUpdateDelayNotPassed")
+            }
+            Operator::OperatorErrors::PendingStakeUpdateRequest(_) => {
+                write!(f, "PendingStakeUpdateRequest")
+            }
+            Operator::OperatorErrors::VaultAlreadyStakedInDSS(_) => {
+                write!(f, "VaultAlreadyStakedInDSS")
+            }
+            Operator::OperatorErrors::VaultNotAChildVault(_) => {
+                write!(f, "VaultNotAChildVault")
+            }
+            Operator::OperatorErrors::VaultNotStakedInDSS(_) => {
+                write!(f, "VaultNotStakedInDSS")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Operator::OperatorErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Operator::OperatorErrors::AllVaultsNotUnstakedFromDSS(_) => {
+                write!(f, "All vaults not unstaked from DSS")
+            }
+            Operator::OperatorErrors::DSSHookCallReverted(_) => {
+                write!(f, "DSS hook call reverted")
+            }
+            Operator::OperatorErrors::InvalidQueuedStakeUpdateInput(_) => {
+                write!(f, "Invalid queued stake update input")
+            }
+            Operator::OperatorErrors::MaxDSSCapacityReached(_) => {
+                write!(f, "Max DSS capacity reached")
+            }
+            Operator::OperatorErrors::NotEnoughGas(_) => {
+                write!(f, "Not enough gas")
+            }
+            Operator::OperatorErrors::OperatorAlreadyRegisteredToDSS(_) => {
+                write!(f, "Operator already registered to DSS")
+            }
+            Operator::OperatorErrors::OperatorNotValidatingForDSS(_) => {
+                write!(f, "Operator not validating for DSS")
+            }
+            Operator::OperatorErrors::OperatorStakeUpdateDelayNotPassed(_) => {
+                write!(f, "Operator stake update delay not passed")
+            }
+            Operator::OperatorErrors::PendingStakeUpdateRequest(_) => {
+                write!(f, "Pending stake update request")
+            }
+            Operator::OperatorErrors::VaultAlreadyStakedInDSS(_) => {
+                write!(f, "Vault already staked in DSS")
+            }
+            Operator::OperatorErrors::VaultNotAChildVault(_) => {
+                write!(f, "Vault not a child vault")
+            }
+            Operator::OperatorErrors::VaultNotStakedInDSS(_) => {
+                write!(f, "Vault not staked in DSS")
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OperatorError<E: std::fmt::Debug> {
+    #[error("Operator error: {0}")]
+    Operator(Operator::OperatorErrors),
+    #[error(transparent)]
+    Inner(E),
+}
+
+impl DecodeError<ErrorPayload> for Operator::OperatorErrors {
+    fn decode_error(error: &ErrorPayload) -> Option<Operator::OperatorErrors> {
+        error.as_decoded_error::<Operator::OperatorErrors>(true)
+    }
+}
+
+impl From<ErrorPayload> for OperatorError<ErrorPayload> {
+    fn from(value: ErrorPayload) -> Self {
+        match Operator::OperatorErrors::decode_error(&value) {
+            Some(error) => OperatorError::Operator(error),
+            None => OperatorError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<TransportError> for Operator::OperatorErrors {
+    fn decode_error(error: &TransportError) -> Option<Operator::OperatorErrors> {
+        match error {
+            RpcError::ErrorResp(error) => error.as_decoded_error::<Operator::OperatorErrors>(true),
+            _ => None,
+        }
+    }
+}
+
+impl From<TransportError> for OperatorError<TransportError> {
+    fn from(value: TransportError) -> Self {
+        match Operator::OperatorErrors::decode_error(&value) {
+            Some(error) => OperatorError::Operator(error),
+            _ => OperatorError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<alloy::contract::Error> for Operator::OperatorErrors {
+    fn decode_error(error: &alloy::contract::Error) -> Option<Operator::OperatorErrors> {
+        match error {
+            alloy::contract::Error::TransportError(transport_error) => {
+                Operator::OperatorErrors::decode_error(transport_error)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for OperatorError<alloy::contract::Error> {
+    fn from(value: alloy::contract::Error) -> Self {
+        match Operator::OperatorErrors::decode_error(&value) {
+            Some(error) => OperatorError::Operator(error),
+            _ => OperatorError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<PendingTransactionError> for Operator::OperatorErrors {
+    fn decode_error(error: &PendingTransactionError) -> Option<Operator::OperatorErrors> {
+        match error {
+            PendingTransactionError::TransportError(transport_error) => {
+                Operator::OperatorErrors::decode_error(transport_error)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<PendingTransactionError> for OperatorError<PendingTransactionError> {
+    fn from(value: PendingTransactionError) -> Self {
+        match Operator::OperatorErrors::decode_error(&value) {
+            Some(error) => OperatorError::Operator(error),
+            _ => OperatorError::Inner(value),
+        }
+    }
+}

--- a/crates/contracts/src/core/mod.rs
+++ b/crates/contracts/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod contract;
 pub mod interface;
+pub mod library;

--- a/crates/contracts/src/erc20/contract.rs
+++ b/crates/contracts/src/erc20/contract.rs
@@ -67,29 +67,35 @@ impl std::fmt::Display for ERC20::ERC20Errors {
 #[derive(Debug, thiserror::Error)]
 pub enum ERC20Error<E: std::fmt::Debug> {
     #[error("ERC20 error: {0}")]
-    Revert(ERC20::ERC20Errors),
+    ERC20(ERC20::ERC20Errors),
     #[error(transparent)]
     Inner(E),
 }
 
 impl<E: std::fmt::Debug> From<ERC20::ERC20Errors> for ERC20Error<E> {
     fn from(error: ERC20::ERC20Errors) -> Self {
-        ERC20Error::Revert(error)
+        ERC20Error::ERC20(error)
+    }
+}
+
+impl DecodeError<ErrorPayload> for ERC20::ERC20Errors {
+    fn decode_error(error: &ErrorPayload) -> Option<ERC20::ERC20Errors> {
+        error.as_decoded_error::<ERC20::ERC20Errors>(true)
     }
 }
 
 impl From<ErrorPayload> for ERC20Error<ErrorPayload> {
     fn from(value: ErrorPayload) -> Self {
         match value.as_decoded_error::<ERC20::ERC20Errors>(true) {
-            Some(error) => ERC20Error::Revert(error),
+            Some(error) => ERC20Error::ERC20(error),
             None => ERC20Error::Inner(value),
         }
     }
 }
 
-impl DecodeError<ERC20::ERC20Errors> for TransportError {
-    fn decode_error(&self) -> Option<ERC20::ERC20Errors> {
-        match self {
+impl DecodeError<TransportError> for ERC20::ERC20Errors {
+    fn decode_error(error: &TransportError) -> Option<ERC20::ERC20Errors> {
+        match error {
             RpcError::ErrorResp(error) => error.as_decoded_error::<ERC20::ERC20Errors>(true),
             _ => None,
         }
@@ -98,18 +104,18 @@ impl DecodeError<ERC20::ERC20Errors> for TransportError {
 
 impl From<TransportError> for ERC20Error<TransportError> {
     fn from(value: TransportError) -> Self {
-        match value.decode_error() {
-            Some(error) => ERC20Error::Revert(error),
+        match ERC20::ERC20Errors::decode_error(&value) {
+            Some(error) => ERC20Error::ERC20(error),
             _ => ERC20Error::Inner(value),
         }
     }
 }
 
-impl DecodeError<ERC20::ERC20Errors> for alloy::contract::Error {
-    fn decode_error(&self) -> Option<ERC20::ERC20Errors> {
-        match self {
+impl DecodeError<alloy::contract::Error> for ERC20::ERC20Errors {
+    fn decode_error(error: &alloy::contract::Error) -> Option<ERC20::ERC20Errors> {
+        match error {
             alloy::contract::Error::TransportError(transport_error) => {
-                transport_error.decode_error()
+                ERC20::ERC20Errors::decode_error(transport_error)
             }
             _ => None,
         }
@@ -118,18 +124,18 @@ impl DecodeError<ERC20::ERC20Errors> for alloy::contract::Error {
 
 impl From<alloy::contract::Error> for ERC20Error<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
-        match value.decode_error() {
-            Some(error) => ERC20Error::Revert(error),
+        match ERC20::ERC20Errors::decode_error(&value) {
+            Some(error) => ERC20Error::ERC20(error),
             _ => ERC20Error::Inner(value),
         }
     }
 }
 
-impl DecodeError<ERC20::ERC20Errors> for PendingTransactionError {
-    fn decode_error(&self) -> Option<ERC20::ERC20Errors> {
-        match self {
+impl DecodeError<PendingTransactionError> for ERC20::ERC20Errors {
+    fn decode_error(error: &PendingTransactionError) -> Option<ERC20::ERC20Errors> {
+        match error {
             PendingTransactionError::TransportError(transport_error) => {
-                transport_error.decode_error()
+                ERC20::ERC20Errors::decode_error(transport_error)
             }
             _ => None,
         }
@@ -138,8 +144,8 @@ impl DecodeError<ERC20::ERC20Errors> for PendingTransactionError {
 
 impl From<PendingTransactionError> for ERC20Error<PendingTransactionError> {
     fn from(value: PendingTransactionError) -> Self {
-        match value.decode_error() {
-            Some(error) => ERC20Error::Revert(error),
+        match ERC20::ERC20Errors::decode_error(&value) {
+            Some(error) => ERC20Error::ERC20(error),
             _ => ERC20Error::Inner(value),
         }
     }

--- a/crates/contracts/src/erc20/contract.rs
+++ b/crates/contracts/src/erc20/contract.rs
@@ -1,0 +1,146 @@
+use alloy::{
+    providers::PendingTransactionError,
+    rpc::json_rpc::ErrorPayload,
+    sol,
+    transports::{RpcError, TransportError},
+};
+
+use crate::error::DecodeError;
+
+sol!(
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    ERC20,
+    "abi/ERC20.json",
+);
+
+impl std::fmt::Debug for ERC20::ERC20Errors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ERC20::ERC20Errors::ERC20InsufficientAllowance(_) => {
+                write!(f, "ERC20InsufficientAllowance")
+            }
+            ERC20::ERC20Errors::ERC20InsufficientBalance(_) => {
+                write!(f, "ERC20InsufficientBalance")
+            }
+            ERC20::ERC20Errors::ERC20InvalidApprover(_) => {
+                write!(f, "ERC20InvalidApprover")
+            }
+            ERC20::ERC20Errors::ERC20InvalidReceiver(_) => {
+                write!(f, "ERC20InvalidReceiver")
+            }
+            ERC20::ERC20Errors::ERC20InvalidSender(_) => {
+                write!(f, "ERC20InvalidSender")
+            }
+            ERC20::ERC20Errors::ERC20InvalidSpender(_) => {
+                write!(f, "ERC20InvalidSpender")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ERC20::ERC20Errors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ERC20::ERC20Errors::ERC20InsufficientAllowance(_) => {
+                write!(f, "ERC20 insufficient allowance")
+            }
+            ERC20::ERC20Errors::ERC20InsufficientBalance(_) => {
+                write!(f, "ERC20 insufficient balance")
+            }
+            ERC20::ERC20Errors::ERC20InvalidApprover(_) => {
+                write!(f, "ERC20 invalid approver")
+            }
+            ERC20::ERC20Errors::ERC20InvalidReceiver(_) => {
+                write!(f, "ERC20 invalid receiver")
+            }
+            ERC20::ERC20Errors::ERC20InvalidSender(_) => {
+                write!(f, "ERC20 invalid sender")
+            }
+            ERC20::ERC20Errors::ERC20InvalidSpender(_) => {
+                write!(f, "ERC20 invalid spender")
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ERC20Error<E: std::fmt::Debug> {
+    #[error("ERC20 error: {0}")]
+    Revert(ERC20::ERC20Errors),
+    #[error(transparent)]
+    Inner(E),
+}
+
+impl<E: std::fmt::Debug> From<ERC20::ERC20Errors> for ERC20Error<E> {
+    fn from(error: ERC20::ERC20Errors) -> Self {
+        ERC20Error::Revert(error)
+    }
+}
+
+impl From<ErrorPayload> for ERC20Error<ErrorPayload> {
+    fn from(value: ErrorPayload) -> Self {
+        match value.as_decoded_error::<ERC20::ERC20Errors>(true) {
+            Some(error) => ERC20Error::Revert(error),
+            None => ERC20Error::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<ERC20::ERC20Errors> for TransportError {
+    fn decode_error(&self) -> Option<ERC20::ERC20Errors> {
+        match self {
+            RpcError::ErrorResp(error) => error.as_decoded_error::<ERC20::ERC20Errors>(true),
+            _ => None,
+        }
+    }
+}
+
+impl From<TransportError> for ERC20Error<TransportError> {
+    fn from(value: TransportError) -> Self {
+        match value.decode_error() {
+            Some(error) => ERC20Error::Revert(error),
+            _ => ERC20Error::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<ERC20::ERC20Errors> for alloy::contract::Error {
+    fn decode_error(&self) -> Option<ERC20::ERC20Errors> {
+        match self {
+            alloy::contract::Error::TransportError(transport_error) => {
+                transport_error.decode_error()
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for ERC20Error<alloy::contract::Error> {
+    fn from(value: alloy::contract::Error) -> Self {
+        match value.decode_error() {
+            Some(error) => ERC20Error::Revert(error),
+            _ => ERC20Error::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<ERC20::ERC20Errors> for PendingTransactionError {
+    fn decode_error(&self) -> Option<ERC20::ERC20Errors> {
+        match self {
+            PendingTransactionError::TransportError(transport_error) => {
+                transport_error.decode_error()
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<PendingTransactionError> for ERC20Error<PendingTransactionError> {
+    fn from(value: PendingTransactionError) -> Self {
+        match value.decode_error() {
+            Some(error) => ERC20Error::Revert(error),
+            _ => ERC20Error::Inner(value),
+        }
+    }
+}

--- a/crates/contracts/src/erc20/interface.rs
+++ b/crates/contracts/src/erc20/interface.rs
@@ -3,6 +3,13 @@ use alloy::sol;
 sol!(
     #[allow(missing_docs)]
     #[sol(rpc)]
+    IERC20Metadata,
+    "abi/IERC20Metadata.json",
+);
+
+sol!(
+    #[allow(missing_docs)]
+    #[sol(rpc)]
     IERC20,
     "abi/IERC20.json",
 );

--- a/crates/contracts/src/erc20/library.rs
+++ b/crates/contracts/src/erc20/library.rs
@@ -1,11 +1,9 @@
 use alloy::{
-    providers::PendingTransactionError,
-    rpc::json_rpc::ErrorPayload,
-    sol,
-    transports::{RpcError, TransportError},
+    providers::PendingTransactionError, rpc::json_rpc::ErrorPayload, sol,
+    transports::TransportError,
 };
 
-use crate::error::DecodeError;
+use crate::{error::DecodeError, impl_decode_error};
 
 sol!(
     #[allow(missing_docs)]
@@ -67,6 +65,8 @@ impl std::fmt::Display for SafeTransferLib::SafeTransferLibErrors {
     }
 }
 
+impl_decode_error!(SafeTransferLib::SafeTransferLibErrors);
+
 #[derive(Debug, thiserror::Error)]
 pub enum SafeTransferLibError<E: std::fmt::Debug> {
     #[error("SafeTransferLib error: {0}")]
@@ -81,28 +81,11 @@ impl<E: std::fmt::Debug> From<SafeTransferLib::SafeTransferLibErrors> for SafeTr
     }
 }
 
-impl DecodeError<ErrorPayload> for SafeTransferLib::SafeTransferLibErrors {
-    fn decode_error(error: &ErrorPayload) -> Option<SafeTransferLib::SafeTransferLibErrors> {
-        error.as_decoded_error::<SafeTransferLib::SafeTransferLibErrors>(true)
-    }
-}
-
 impl From<ErrorPayload> for SafeTransferLibError<ErrorPayload> {
     fn from(value: ErrorPayload) -> Self {
         match SafeTransferLib::SafeTransferLibErrors::decode_error(&value) {
             Some(error) => SafeTransferLibError::SafeTransferLib(error),
             None => SafeTransferLibError::Inner(value),
-        }
-    }
-}
-
-impl DecodeError<TransportError> for SafeTransferLib::SafeTransferLibErrors {
-    fn decode_error(error: &TransportError) -> Option<SafeTransferLib::SafeTransferLibErrors> {
-        match error {
-            RpcError::ErrorResp(error) => {
-                error.as_decoded_error::<SafeTransferLib::SafeTransferLibErrors>(true)
-            }
-            _ => None,
         }
     }
 }
@@ -116,37 +99,11 @@ impl From<TransportError> for SafeTransferLibError<TransportError> {
     }
 }
 
-impl DecodeError<alloy::contract::Error> for SafeTransferLib::SafeTransferLibErrors {
-    fn decode_error(
-        error: &alloy::contract::Error,
-    ) -> Option<SafeTransferLib::SafeTransferLibErrors> {
-        match error {
-            alloy::contract::Error::TransportError(transport_error) => {
-                SafeTransferLib::SafeTransferLibErrors::decode_error(transport_error)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl From<alloy::contract::Error> for SafeTransferLibError<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
         match SafeTransferLib::SafeTransferLibErrors::decode_error(&value) {
             Some(error) => SafeTransferLibError::SafeTransferLib(error),
             _ => SafeTransferLibError::Inner(value),
-        }
-    }
-}
-
-impl DecodeError<PendingTransactionError> for SafeTransferLib::SafeTransferLibErrors {
-    fn decode_error(
-        error: &PendingTransactionError,
-    ) -> Option<SafeTransferLib::SafeTransferLibErrors> {
-        match error {
-            PendingTransactionError::TransportError(transport_error) => {
-                SafeTransferLib::SafeTransferLibErrors::decode_error(transport_error)
-            }
-            _ => None,
         }
     }
 }

--- a/crates/contracts/src/erc20/library.rs
+++ b/crates/contracts/src/erc20/library.rs
@@ -1,0 +1,161 @@
+use alloy::{
+    providers::PendingTransactionError,
+    rpc::json_rpc::ErrorPayload,
+    sol,
+    transports::{RpcError, TransportError},
+};
+
+use crate::error::DecodeError;
+
+sol!(
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    SafeTransferLib,
+    "abi/SafeTransferLib.json",
+);
+
+impl std::fmt::Debug for SafeTransferLib::SafeTransferLibErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SafeTransferLib::SafeTransferLibErrors::ApproveFailed(_) => {
+                write!(f, "ApproveFailed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::ETHTransferFailed(_) => {
+                write!(f, "ETHTransferFailed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::Permit2AmountOverflow(_) => {
+                write!(f, "Permit2AmountOverflow")
+            }
+            SafeTransferLib::SafeTransferLibErrors::Permit2Failed(_) => {
+                write!(f, "Permit2Failed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::TransferFailed(_) => {
+                write!(f, "TransferFailed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::TransferFromFailed(_) => {
+                write!(f, "TransferFromFailed")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for SafeTransferLib::SafeTransferLibErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SafeTransferLib::SafeTransferLibErrors::ApproveFailed(_) => {
+                write!(f, "Approve failed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::ETHTransferFailed(_) => {
+                write!(f, "ETH transfer failed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::Permit2AmountOverflow(_) => {
+                write!(f, "Permit2 amount overflow")
+            }
+            SafeTransferLib::SafeTransferLibErrors::Permit2Failed(_) => {
+                write!(f, "Permit2 failed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::TransferFailed(_) => {
+                write!(f, "Transfer failed")
+            }
+            SafeTransferLib::SafeTransferLibErrors::TransferFromFailed(_) => {
+                write!(
+                    f,
+                    "Transfer failed. Check that you have enough token balance for the transfer"
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SafeTransferLibError<E: std::fmt::Debug> {
+    #[error("SafeTransferLib error: {0}")]
+    SafeTransferLib(SafeTransferLib::SafeTransferLibErrors),
+    #[error(transparent)]
+    Inner(E),
+}
+
+impl<E: std::fmt::Debug> From<SafeTransferLib::SafeTransferLibErrors> for SafeTransferLibError<E> {
+    fn from(error: SafeTransferLib::SafeTransferLibErrors) -> Self {
+        SafeTransferLibError::SafeTransferLib(error)
+    }
+}
+
+impl DecodeError<ErrorPayload> for SafeTransferLib::SafeTransferLibErrors {
+    fn decode_error(error: &ErrorPayload) -> Option<SafeTransferLib::SafeTransferLibErrors> {
+        error.as_decoded_error::<SafeTransferLib::SafeTransferLibErrors>(true)
+    }
+}
+
+impl From<ErrorPayload> for SafeTransferLibError<ErrorPayload> {
+    fn from(value: ErrorPayload) -> Self {
+        match SafeTransferLib::SafeTransferLibErrors::decode_error(&value) {
+            Some(error) => SafeTransferLibError::SafeTransferLib(error),
+            None => SafeTransferLibError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<TransportError> for SafeTransferLib::SafeTransferLibErrors {
+    fn decode_error(error: &TransportError) -> Option<SafeTransferLib::SafeTransferLibErrors> {
+        match error {
+            RpcError::ErrorResp(error) => {
+                error.as_decoded_error::<SafeTransferLib::SafeTransferLibErrors>(true)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<TransportError> for SafeTransferLibError<TransportError> {
+    fn from(value: TransportError) -> Self {
+        match SafeTransferLib::SafeTransferLibErrors::decode_error(&value) {
+            Some(error) => SafeTransferLibError::SafeTransferLib(error),
+            _ => SafeTransferLibError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<alloy::contract::Error> for SafeTransferLib::SafeTransferLibErrors {
+    fn decode_error(
+        error: &alloy::contract::Error,
+    ) -> Option<SafeTransferLib::SafeTransferLibErrors> {
+        match error {
+            alloy::contract::Error::TransportError(transport_error) => {
+                SafeTransferLib::SafeTransferLibErrors::decode_error(transport_error)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for SafeTransferLibError<alloy::contract::Error> {
+    fn from(value: alloy::contract::Error) -> Self {
+        match SafeTransferLib::SafeTransferLibErrors::decode_error(&value) {
+            Some(error) => SafeTransferLibError::SafeTransferLib(error),
+            _ => SafeTransferLibError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<PendingTransactionError> for SafeTransferLib::SafeTransferLibErrors {
+    fn decode_error(
+        error: &PendingTransactionError,
+    ) -> Option<SafeTransferLib::SafeTransferLibErrors> {
+        match error {
+            PendingTransactionError::TransportError(transport_error) => {
+                SafeTransferLib::SafeTransferLibErrors::decode_error(transport_error)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<PendingTransactionError> for SafeTransferLibError<PendingTransactionError> {
+    fn from(value: PendingTransactionError) -> Self {
+        match SafeTransferLib::SafeTransferLibErrors::decode_error(&value) {
+            Some(error) => SafeTransferLibError::SafeTransferLib(error),
+            _ => SafeTransferLibError::Inner(value),
+        }
+    }
+}

--- a/crates/contracts/src/erc20/mintable.rs
+++ b/crates/contracts/src/erc20/mintable.rs
@@ -76,16 +76,16 @@ impl std::fmt::Display for ERC20Mintable::ERC20MintableErrors {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error<E: std::fmt::Debug> {
+pub enum ERC20MintableError<E: std::fmt::Debug> {
     #[error("ERC20Mintable error: {0}")]
-    ERC20MintableError(ERC20Mintable::ERC20MintableErrors),
+    Revert(ERC20Mintable::ERC20MintableErrors),
     #[error(transparent)]
     Inner(E),
 }
 
-impl<E: std::fmt::Debug> From<ERC20Mintable::ERC20MintableErrors> for Error<E> {
+impl<E: std::fmt::Debug> From<ERC20Mintable::ERC20MintableErrors> for ERC20MintableError<E> {
     fn from(err: ERC20Mintable::ERC20MintableErrors) -> Self {
-        Error::ERC20MintableError(err)
+        ERC20MintableError::Revert(err)
     }
 }
 
@@ -95,11 +95,11 @@ impl DecodeError<ERC20Mintable::ERC20MintableErrors> for ErrorPayload {
     }
 }
 
-impl From<ErrorPayload> for Error<ErrorPayload> {
+impl From<ErrorPayload> for ERC20MintableError<ErrorPayload> {
     fn from(err: ErrorPayload) -> Self {
         match err.decode_error() {
-            Some(err) => Error::ERC20MintableError(err),
-            None => Error::Inner(err),
+            Some(err) => ERC20MintableError::Revert(err),
+            None => ERC20MintableError::Inner(err),
         }
     }
 }
@@ -113,11 +113,11 @@ impl DecodeError<ERC20Mintable::ERC20MintableErrors> for TransportError {
     }
 }
 
-impl From<TransportError> for Error<TransportError> {
+impl From<TransportError> for ERC20MintableError<TransportError> {
     fn from(err: TransportError) -> Self {
         match err.decode_error() {
-            Some(err) => Error::ERC20MintableError(err),
-            None => Error::Inner(err),
+            Some(err) => ERC20MintableError::Revert(err),
+            None => ERC20MintableError::Inner(err),
         }
     }
 }
@@ -131,11 +131,11 @@ impl DecodeError<ERC20Mintable::ERC20MintableErrors> for alloy::contract::Error 
     }
 }
 
-impl From<alloy::contract::Error> for Error<alloy::contract::Error> {
+impl From<alloy::contract::Error> for ERC20MintableError<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
         match value.decode_error() {
-            Some(err) => Error::ERC20MintableError(err),
-            None => Error::Inner(value),
+            Some(err) => ERC20MintableError::Revert(err),
+            None => ERC20MintableError::Inner(value),
         }
     }
 }
@@ -149,11 +149,11 @@ impl DecodeError<ERC20Mintable::ERC20MintableErrors> for PendingTransactionError
     }
 }
 
-impl From<PendingTransactionError> for Error<PendingTransactionError> {
+impl From<PendingTransactionError> for ERC20MintableError<PendingTransactionError> {
     fn from(value: PendingTransactionError) -> Self {
         match value.decode_error() {
-            Some(err) => Error::ERC20MintableError(err),
-            None => Error::Inner(value),
+            Some(err) => ERC20MintableError::Revert(err),
+            None => ERC20MintableError::Inner(value),
         }
     }
 }

--- a/crates/contracts/src/erc20/mintable.rs
+++ b/crates/contracts/src/erc20/mintable.rs
@@ -1,4 +1,9 @@
-use alloy::sol;
+use alloy::{
+    providers::PendingTransactionError, rpc::json_rpc::ErrorPayload, sol,
+    transports::TransportError,
+};
+
+use crate::error::DecodeError;
 
 sol!(
     #[allow(clippy::too_many_arguments)]
@@ -7,3 +12,148 @@ sol!(
     ERC20Mintable,
     "abi/ERC20Mintable.json",
 );
+
+impl std::fmt::Debug for ERC20Mintable::ERC20MintableErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ERC20Mintable::ERC20MintableErrors::AddressZero(_) => {
+                write!(f, "AddressZero")
+            }
+            ERC20Mintable::ERC20MintableErrors::AllowanceOverflow(_) => {
+                write!(f, "AllowanceOverflow")
+            }
+            ERC20Mintable::ERC20MintableErrors::AllowanceUnderflow(_) => {
+                write!(f, "AllowanceUnderflow")
+            }
+            ERC20Mintable::ERC20MintableErrors::InsufficientAllowance(_) => {
+                write!(f, "InsufficientAllowance")
+            }
+            ERC20Mintable::ERC20MintableErrors::InsufficientBalance(_) => {
+                write!(f, "InsufficientBalance")
+            }
+            ERC20Mintable::ERC20MintableErrors::InvalidPermit(_) => {
+                write!(f, "InvalidPermit")
+            }
+            ERC20Mintable::ERC20MintableErrors::PermitExpired(_) => {
+                write!(f, "PermitExpired")
+            }
+            ERC20Mintable::ERC20MintableErrors::TotalSupplyOverflow(_) => {
+                write!(f, "TotalSupplyOverflow")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ERC20Mintable::ERC20MintableErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ERC20Mintable::ERC20MintableErrors::AddressZero(_) => {
+                write!(f, "Address is zero")
+            }
+            ERC20Mintable::ERC20MintableErrors::AllowanceOverflow(_) => {
+                write!(f, "Allowance overflow")
+            }
+            ERC20Mintable::ERC20MintableErrors::AllowanceUnderflow(_) => {
+                write!(f, "Allowance underflow")
+            }
+            ERC20Mintable::ERC20MintableErrors::InsufficientAllowance(_) => {
+                write!(f, "Insufficient allowance")
+            }
+            ERC20Mintable::ERC20MintableErrors::InsufficientBalance(_) => {
+                write!(f, "Insufficient balance")
+            }
+            ERC20Mintable::ERC20MintableErrors::InvalidPermit(_) => {
+                write!(f, "Invalid permit")
+            }
+            ERC20Mintable::ERC20MintableErrors::PermitExpired(_) => {
+                write!(f, "Permit expired")
+            }
+            ERC20Mintable::ERC20MintableErrors::TotalSupplyOverflow(_) => {
+                write!(f, "Total supply overflow")
+            }
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error<E: std::fmt::Debug> {
+    #[error("ERC20Mintable error: {0}")]
+    ERC20MintableError(ERC20Mintable::ERC20MintableErrors),
+    #[error(transparent)]
+    Inner(E),
+}
+
+impl<E: std::fmt::Debug> From<ERC20Mintable::ERC20MintableErrors> for Error<E> {
+    fn from(err: ERC20Mintable::ERC20MintableErrors) -> Self {
+        Error::ERC20MintableError(err)
+    }
+}
+
+impl DecodeError<ERC20Mintable::ERC20MintableErrors> for ErrorPayload {
+    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        self.as_decoded_error::<ERC20Mintable::ERC20MintableErrors>(true)
+    }
+}
+
+impl From<ErrorPayload> for Error<ErrorPayload> {
+    fn from(err: ErrorPayload) -> Self {
+        match err.decode_error() {
+            Some(err) => Error::ERC20MintableError(err),
+            None => Error::Inner(err),
+        }
+    }
+}
+
+impl DecodeError<ERC20Mintable::ERC20MintableErrors> for TransportError {
+    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        match self {
+            alloy::transports::RpcError::ErrorResp(error) => error.decode_error(),
+            _ => None,
+        }
+    }
+}
+
+impl From<TransportError> for Error<TransportError> {
+    fn from(err: TransportError) -> Self {
+        match err.decode_error() {
+            Some(err) => Error::ERC20MintableError(err),
+            None => Error::Inner(err),
+        }
+    }
+}
+
+impl DecodeError<ERC20Mintable::ERC20MintableErrors> for alloy::contract::Error {
+    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        match self {
+            alloy::contract::Error::TransportError(error) => error.decode_error(),
+            _ => None,
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for Error<alloy::contract::Error> {
+    fn from(value: alloy::contract::Error) -> Self {
+        match value.decode_error() {
+            Some(err) => Error::ERC20MintableError(err),
+            None => Error::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<ERC20Mintable::ERC20MintableErrors> for PendingTransactionError {
+    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        match self {
+            PendingTransactionError::TransportError(error) => error.decode_error(),
+            _ => None,
+        }
+    }
+}
+
+impl From<PendingTransactionError> for Error<PendingTransactionError> {
+    fn from(value: PendingTransactionError) -> Self {
+        match value.decode_error() {
+            Some(err) => Error::ERC20MintableError(err),
+            None => Error::Inner(value),
+        }
+    }
+}

--- a/crates/contracts/src/erc20/mintable.rs
+++ b/crates/contracts/src/erc20/mintable.rs
@@ -89,43 +89,47 @@ impl<E: std::fmt::Debug> From<ERC20Mintable::ERC20MintableErrors> for ERC20Minta
     }
 }
 
-impl DecodeError<ERC20Mintable::ERC20MintableErrors> for ErrorPayload {
-    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        self.as_decoded_error::<ERC20Mintable::ERC20MintableErrors>(true)
+impl DecodeError<ErrorPayload> for ERC20Mintable::ERC20MintableErrors {
+    fn decode_error(error: &ErrorPayload) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        error.as_decoded_error::<ERC20Mintable::ERC20MintableErrors>(true)
     }
 }
 
 impl From<ErrorPayload> for ERC20MintableError<ErrorPayload> {
-    fn from(err: ErrorPayload) -> Self {
-        match err.decode_error() {
+    fn from(error: ErrorPayload) -> Self {
+        match ERC20Mintable::ERC20MintableErrors::decode_error(&error) {
             Some(err) => ERC20MintableError::Revert(err),
-            None => ERC20MintableError::Inner(err),
+            None => ERC20MintableError::Inner(error),
         }
     }
 }
 
-impl DecodeError<ERC20Mintable::ERC20MintableErrors> for TransportError {
-    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        match self {
-            alloy::transports::RpcError::ErrorResp(error) => error.decode_error(),
+impl DecodeError<TransportError> for ERC20Mintable::ERC20MintableErrors {
+    fn decode_error(error: &TransportError) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        match error {
+            alloy::transports::RpcError::ErrorResp(error) => {
+                ERC20Mintable::ERC20MintableErrors::decode_error(error)
+            }
             _ => None,
         }
     }
 }
 
 impl From<TransportError> for ERC20MintableError<TransportError> {
-    fn from(err: TransportError) -> Self {
-        match err.decode_error() {
+    fn from(error: TransportError) -> Self {
+        match ERC20Mintable::ERC20MintableErrors::decode_error(&error) {
             Some(err) => ERC20MintableError::Revert(err),
-            None => ERC20MintableError::Inner(err),
+            None => ERC20MintableError::Inner(error),
         }
     }
 }
 
-impl DecodeError<ERC20Mintable::ERC20MintableErrors> for alloy::contract::Error {
-    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        match self {
-            alloy::contract::Error::TransportError(error) => error.decode_error(),
+impl DecodeError<alloy::contract::Error> for ERC20Mintable::ERC20MintableErrors {
+    fn decode_error(error: &alloy::contract::Error) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        match error {
+            alloy::contract::Error::TransportError(error) => {
+                ERC20Mintable::ERC20MintableErrors::decode_error(error)
+            }
             _ => None,
         }
     }
@@ -133,17 +137,19 @@ impl DecodeError<ERC20Mintable::ERC20MintableErrors> for alloy::contract::Error 
 
 impl From<alloy::contract::Error> for ERC20MintableError<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
-        match value.decode_error() {
+        match ERC20Mintable::ERC20MintableErrors::decode_error(&value) {
             Some(err) => ERC20MintableError::Revert(err),
             None => ERC20MintableError::Inner(value),
         }
     }
 }
 
-impl DecodeError<ERC20Mintable::ERC20MintableErrors> for PendingTransactionError {
-    fn decode_error(&self) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        match self {
-            PendingTransactionError::TransportError(error) => error.decode_error(),
+impl DecodeError<PendingTransactionError> for ERC20Mintable::ERC20MintableErrors {
+    fn decode_error(error: &PendingTransactionError) -> Option<ERC20Mintable::ERC20MintableErrors> {
+        match error {
+            PendingTransactionError::TransportError(error) => {
+                ERC20Mintable::ERC20MintableErrors::decode_error(error)
+            }
             _ => None,
         }
     }
@@ -151,7 +157,7 @@ impl DecodeError<ERC20Mintable::ERC20MintableErrors> for PendingTransactionError
 
 impl From<PendingTransactionError> for ERC20MintableError<PendingTransactionError> {
     fn from(value: PendingTransactionError) -> Self {
-        match value.decode_error() {
+        match ERC20Mintable::ERC20MintableErrors::decode_error(&value) {
             Some(err) => ERC20MintableError::Revert(err),
             None => ERC20MintableError::Inner(value),
         }

--- a/crates/contracts/src/erc20/mintable.rs
+++ b/crates/contracts/src/erc20/mintable.rs
@@ -3,7 +3,7 @@ use alloy::{
     transports::TransportError,
 };
 
-use crate::error::DecodeError;
+use crate::{error::DecodeError, impl_decode_error};
 
 sol!(
     #[allow(clippy::too_many_arguments)]
@@ -75,6 +75,8 @@ impl std::fmt::Display for ERC20Mintable::ERC20MintableErrors {
     }
 }
 
+impl_decode_error!(ERC20Mintable::ERC20MintableErrors);
+
 #[derive(thiserror::Error, Debug)]
 pub enum ERC20MintableError<E: std::fmt::Debug> {
     #[error("ERC20Mintable error: {0}")]
@@ -89,28 +91,11 @@ impl<E: std::fmt::Debug> From<ERC20Mintable::ERC20MintableErrors> for ERC20Minta
     }
 }
 
-impl DecodeError<ErrorPayload> for ERC20Mintable::ERC20MintableErrors {
-    fn decode_error(error: &ErrorPayload) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        error.as_decoded_error::<ERC20Mintable::ERC20MintableErrors>(true)
-    }
-}
-
 impl From<ErrorPayload> for ERC20MintableError<ErrorPayload> {
     fn from(error: ErrorPayload) -> Self {
         match ERC20Mintable::ERC20MintableErrors::decode_error(&error) {
             Some(err) => ERC20MintableError::Revert(err),
             None => ERC20MintableError::Inner(error),
-        }
-    }
-}
-
-impl DecodeError<TransportError> for ERC20Mintable::ERC20MintableErrors {
-    fn decode_error(error: &TransportError) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        match error {
-            alloy::transports::RpcError::ErrorResp(error) => {
-                ERC20Mintable::ERC20MintableErrors::decode_error(error)
-            }
-            _ => None,
         }
     }
 }
@@ -124,33 +109,11 @@ impl From<TransportError> for ERC20MintableError<TransportError> {
     }
 }
 
-impl DecodeError<alloy::contract::Error> for ERC20Mintable::ERC20MintableErrors {
-    fn decode_error(error: &alloy::contract::Error) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        match error {
-            alloy::contract::Error::TransportError(error) => {
-                ERC20Mintable::ERC20MintableErrors::decode_error(error)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl From<alloy::contract::Error> for ERC20MintableError<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
         match ERC20Mintable::ERC20MintableErrors::decode_error(&value) {
             Some(err) => ERC20MintableError::Revert(err),
             None => ERC20MintableError::Inner(value),
-        }
-    }
-}
-
-impl DecodeError<PendingTransactionError> for ERC20Mintable::ERC20MintableErrors {
-    fn decode_error(error: &PendingTransactionError) -> Option<ERC20Mintable::ERC20MintableErrors> {
-        match error {
-            PendingTransactionError::TransportError(error) => {
-                ERC20Mintable::ERC20MintableErrors::decode_error(error)
-            }
-            _ => None,
         }
     }
 }

--- a/crates/contracts/src/erc20/mod.rs
+++ b/crates/contracts/src/erc20/mod.rs
@@ -1,3 +1,4 @@
 pub mod contract;
 pub mod interface;
+pub mod library;
 pub mod mintable;

--- a/crates/contracts/src/erc20/mod.rs
+++ b/crates/contracts/src/erc20/mod.rs
@@ -1,2 +1,3 @@
+pub mod contract;
 pub mod interface;
 pub mod mintable;

--- a/crates/contracts/src/error.rs
+++ b/crates/contracts/src/error.rs
@@ -1,5 +1,5 @@
 use alloy::sol_types::SolInterface;
 
-pub trait DecodeError<E: SolInterface> {
+pub(crate) trait DecodeError<E: SolInterface> {
     fn decode_error(&self) -> Option<E>;
 }

--- a/crates/contracts/src/error.rs
+++ b/crates/contracts/src/error.rs
@@ -1,0 +1,5 @@
+use alloy::sol_types::SolInterface;
+
+pub trait DecodeError<E: SolInterface> {
+    fn decode_error(&self) -> Option<E>;
+}

--- a/crates/contracts/src/error.rs
+++ b/crates/contracts/src/error.rs
@@ -1,5 +1,5 @@
 use alloy::sol_types::SolInterface;
 
-pub(crate) trait DecodeError<E: SolInterface> {
-    fn decode_error(&self) -> Option<E>;
+pub(crate) trait DecodeError<E>: SolInterface {
+    fn decode_error(value: &E) -> Option<Self>;
 }

--- a/crates/contracts/src/error.rs
+++ b/crates/contracts/src/error.rs
@@ -3,3 +3,51 @@ use alloy::sol_types::SolInterface;
 pub(crate) trait DecodeError<E>: SolInterface {
     fn decode_error(value: &E) -> Option<Self>;
 }
+
+#[macro_export]
+macro_rules! impl_decode_error {
+    ($name:path) => {
+        impl $crate::error::DecodeError<::alloy::rpc::json_rpc::ErrorPayload> for $name {
+            fn decode_error(error: &::alloy::rpc::json_rpc::ErrorPayload) -> Option<$name> {
+                error.as_decoded_error::<$name>(true)
+            }
+        }
+
+        impl $crate::error::DecodeError<::alloy::transports::TransportError> for $name {
+            fn decode_error(error: &::alloy::transports::TransportError) -> Option<$name> {
+                match error {
+                    ::alloy::transports::RpcError::ErrorResp(error) => {
+                        error.as_decoded_error::<$name>(true)
+                    }
+                    _ => None,
+                }
+            }
+        }
+
+        impl $crate::error::DecodeError<::alloy::contract::Error> for $name {
+            fn decode_error(error: &::alloy::contract::Error) -> Option<$name> {
+                match error {
+                    ::alloy::contract::Error::TransportError(transport_error) => {
+                        <$name as $crate::error::DecodeError<::alloy::transports::TransportError>>::decode_error(
+                            transport_error,
+                        )
+                    }
+                    _ => None,
+                }
+            }
+        }
+
+        impl $crate::error::DecodeError<::alloy::providers::PendingTransactionError> for $name {
+            fn decode_error(error: &::alloy::providers::PendingTransactionError) -> Option<$name> {
+                match error {
+                    ::alloy::providers::PendingTransactionError::TransportError(
+                        transport_error,
+                    ) => <$name as $crate::error::DecodeError<
+                        ::alloy::transports::TransportError,
+                    >>::decode_error(transport_error),
+                    _ => None,
+                }
+            }
+        }
+    };
+}

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod core;
 pub mod erc20;
+pub mod error;
 pub mod registry;
 pub mod stake_viewer;
 pub mod vault;

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod core;
 pub mod erc20;
-pub mod error;
+pub(crate) mod error;
 pub mod registry;
 pub mod stake_viewer;
 pub mod vault;

--- a/crates/contracts/src/registry.rs
+++ b/crates/contracts/src/registry.rs
@@ -155,9 +155,9 @@ impl From<ErrorPayload> for RestakingRegistryError<ErrorPayload> {
     }
 }
 
-impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for TransportError {
-    fn decode_error(&self) -> Option<RestakingRegistry::RestakingRegistryErrors> {
-        match self {
+impl DecodeError<TransportError> for RestakingRegistry::RestakingRegistryErrors {
+    fn decode_error(error: &TransportError) -> Option<RestakingRegistry::RestakingRegistryErrors> {
+        match error {
             RpcError::ErrorResp(error) => {
                 error.as_decoded_error::<RestakingRegistry::RestakingRegistryErrors>(true)
             }
@@ -168,18 +168,20 @@ impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for TransportError 
 
 impl From<TransportError> for RestakingRegistryError<TransportError> {
     fn from(value: TransportError) -> Self {
-        match value.decode_error() {
+        match RestakingRegistry::RestakingRegistryErrors::decode_error(&value) {
             Some(error) => RestakingRegistryError::Revert(error),
             _ => RestakingRegistryError::Inner(value),
         }
     }
 }
 
-impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for alloy::contract::Error {
-    fn decode_error(&self) -> Option<RestakingRegistry::RestakingRegistryErrors> {
-        match self {
+impl DecodeError<alloy::contract::Error> for RestakingRegistry::RestakingRegistryErrors {
+    fn decode_error(
+        error: &alloy::contract::Error,
+    ) -> Option<RestakingRegistry::RestakingRegistryErrors> {
+        match error {
             alloy::contract::Error::TransportError(transport_error) => {
-                transport_error.decode_error()
+                RestakingRegistry::RestakingRegistryErrors::decode_error(transport_error)
             }
             _ => None,
         }
@@ -188,18 +190,20 @@ impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for alloy::contract
 
 impl From<alloy::contract::Error> for RestakingRegistryError<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
-        match value.decode_error() {
+        match RestakingRegistry::RestakingRegistryErrors::decode_error(&value) {
             Some(error) => RestakingRegistryError::Revert(error),
             _ => RestakingRegistryError::Inner(value),
         }
     }
 }
 
-impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for PendingTransactionError {
-    fn decode_error(&self) -> Option<RestakingRegistry::RestakingRegistryErrors> {
-        match self {
+impl DecodeError<PendingTransactionError> for RestakingRegistry::RestakingRegistryErrors {
+    fn decode_error(
+        error: &PendingTransactionError,
+    ) -> Option<RestakingRegistry::RestakingRegistryErrors> {
+        match error {
             PendingTransactionError::TransportError(transport_error) => {
-                transport_error.decode_error()
+                RestakingRegistry::RestakingRegistryErrors::decode_error(transport_error)
             }
             _ => None,
         }
@@ -208,7 +212,7 @@ impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for PendingTransact
 
 impl From<PendingTransactionError> for RestakingRegistryError<PendingTransactionError> {
     fn from(value: PendingTransactionError) -> Self {
-        match value.decode_error() {
+        match RestakingRegistry::RestakingRegistryErrors::decode_error(&value) {
             Some(error) => RestakingRegistryError::Revert(error),
             _ => RestakingRegistryError::Inner(value),
         }

--- a/crates/contracts/src/registry.rs
+++ b/crates/contracts/src/registry.rs
@@ -1,4 +1,11 @@
-use alloy::sol;
+use alloy::{
+    providers::PendingTransactionError,
+    rpc::json_rpc::ErrorPayload,
+    sol,
+    transports::{RpcError, TransportError},
+};
+
+use crate::error::DecodeError;
 
 sol!(
     #[allow(missing_docs)]
@@ -6,3 +13,204 @@ sol!(
     RestakingRegistry,
     "abi/RestakingRegistry.json",
 );
+
+impl std::fmt::Debug for RestakingRegistry::RestakingRegistryErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RestakingRegistry::RestakingRegistryErrors::AddressEmptyCode(_) => {
+                write!(f, "AddressEmptyCode")
+            }
+            RestakingRegistry::RestakingRegistryErrors::AddressZero(_) => {
+                write!(f, "AddressZero")
+            }
+            RestakingRegistry::RestakingRegistryErrors::AlreadyInitialized(_) => {
+                write!(f, "AlreadyInitialized")
+            }
+            RestakingRegistry::RestakingRegistryErrors::ERC1967InvalidImplementation(_) => {
+                write!(f, "ERC1967InvalidImplementation")
+            }
+            RestakingRegistry::RestakingRegistryErrors::ERC1967NonPayable(_) => {
+                write!(f, "ERC1967NonPayable")
+            }
+            RestakingRegistry::RestakingRegistryErrors::FailedInnerCall(_) => {
+                write!(f, "FailedInnerCall")
+            }
+            RestakingRegistry::RestakingRegistryErrors::InvalidFourthSegment(_) => {
+                write!(f, "InvalidFourthSegment")
+            }
+            RestakingRegistry::RestakingRegistryErrors::InvalidInitialization(_) => {
+                write!(f, "InvalidInitialization")
+            }
+            RestakingRegistry::RestakingRegistryErrors::InvalidUrlFormat(_) => {
+                write!(f, "InvalidUrlFormat")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NewOwnerIsZeroAddress(_) => {
+                write!(f, "NewOwnerIsZeroAddress")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NoHandoverRequest(_) => {
+                write!(f, "NoHandoverRequest")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NotInitializing(_) => {
+                write!(f, "NotInitializing")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NotKnsOwner(_) => {
+                write!(f, "NotKnsOwner")
+            }
+            RestakingRegistry::RestakingRegistryErrors::UUPSUnauthorizedCallContext(_) => {
+                write!(f, "UUPSUnauthorizedCallContext")
+            }
+            RestakingRegistry::RestakingRegistryErrors::UUPSUnsupportedProxiableUUID(_) => {
+                write!(f, "UUPSUnsupportedProxiableUUID")
+            }
+            RestakingRegistry::RestakingRegistryErrors::Unauthorized(_) => {
+                write!(f, "Unauthorized")
+            }
+            RestakingRegistry::RestakingRegistryErrors::UnexpectedAmtOfDots(_) => {
+                write!(f, "UnexpectedAmtOfDots")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for RestakingRegistry::RestakingRegistryErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RestakingRegistry::RestakingRegistryErrors::AddressEmptyCode(_) => {
+                write!(f, "Address empty code")
+            }
+            RestakingRegistry::RestakingRegistryErrors::AddressZero(_) => {
+                write!(f, "Address zero")
+            }
+            RestakingRegistry::RestakingRegistryErrors::AlreadyInitialized(_) => {
+                write!(f, "Already initialized")
+            }
+            RestakingRegistry::RestakingRegistryErrors::ERC1967InvalidImplementation(_) => {
+                write!(f, "ERC1967 invalid implementation")
+            }
+            RestakingRegistry::RestakingRegistryErrors::ERC1967NonPayable(_) => {
+                write!(f, "ERC1967 non-payable")
+            }
+            RestakingRegistry::RestakingRegistryErrors::FailedInnerCall(_) => {
+                write!(f, "Failed inner call")
+            }
+            RestakingRegistry::RestakingRegistryErrors::InvalidFourthSegment(_) => {
+                write!(f, "Invalid fourth segment")
+            }
+            RestakingRegistry::RestakingRegistryErrors::InvalidInitialization(_) => {
+                write!(f, "Invalid initialization")
+            }
+            RestakingRegistry::RestakingRegistryErrors::InvalidUrlFormat(_) => {
+                write!(f, "Invalid URL format")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NewOwnerIsZeroAddress(_) => {
+                write!(f, "New owner is zero address")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NoHandoverRequest(_) => {
+                write!(f, "No handover request")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NotInitializing(_) => {
+                write!(f, "Not initializing")
+            }
+            RestakingRegistry::RestakingRegistryErrors::NotKnsOwner(_) => {
+                write!(f, "Not KNS owner")
+            }
+            RestakingRegistry::RestakingRegistryErrors::UUPSUnauthorizedCallContext(_) => {
+                write!(f, "UUPS unauthorized call context")
+            }
+            RestakingRegistry::RestakingRegistryErrors::UUPSUnsupportedProxiableUUID(_) => {
+                write!(f, "UUPS unsupported proxiable UUID")
+            }
+            RestakingRegistry::RestakingRegistryErrors::Unauthorized(_) => {
+                write!(f, "Unauthorized")
+            }
+            RestakingRegistry::RestakingRegistryErrors::UnexpectedAmtOfDots(_) => {
+                write!(f, "Unexpected amount of dots")
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RestakingRegistryError<E: std::fmt::Debug> {
+    #[error("RestakingRegistry error: {0}")]
+    Revert(RestakingRegistry::RestakingRegistryErrors),
+    #[error(transparent)]
+    Inner(E),
+}
+
+impl<E: std::fmt::Debug> From<RestakingRegistry::RestakingRegistryErrors>
+    for RestakingRegistryError<E>
+{
+    fn from(error: RestakingRegistry::RestakingRegistryErrors) -> Self {
+        RestakingRegistryError::Revert(error)
+    }
+}
+
+impl From<ErrorPayload> for RestakingRegistryError<ErrorPayload> {
+    fn from(value: ErrorPayload) -> Self {
+        match value.as_decoded_error::<RestakingRegistry::RestakingRegistryErrors>(true) {
+            Some(error) => RestakingRegistryError::Revert(error),
+            None => RestakingRegistryError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for TransportError {
+    fn decode_error(&self) -> Option<RestakingRegistry::RestakingRegistryErrors> {
+        match self {
+            RpcError::ErrorResp(error) => {
+                error.as_decoded_error::<RestakingRegistry::RestakingRegistryErrors>(true)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<TransportError> for RestakingRegistryError<TransportError> {
+    fn from(value: TransportError) -> Self {
+        match value.decode_error() {
+            Some(error) => RestakingRegistryError::Revert(error),
+            _ => RestakingRegistryError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for alloy::contract::Error {
+    fn decode_error(&self) -> Option<RestakingRegistry::RestakingRegistryErrors> {
+        match self {
+            alloy::contract::Error::TransportError(transport_error) => {
+                transport_error.decode_error()
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for RestakingRegistryError<alloy::contract::Error> {
+    fn from(value: alloy::contract::Error) -> Self {
+        match value.decode_error() {
+            Some(error) => RestakingRegistryError::Revert(error),
+            _ => RestakingRegistryError::Inner(value),
+        }
+    }
+}
+
+impl DecodeError<RestakingRegistry::RestakingRegistryErrors> for PendingTransactionError {
+    fn decode_error(&self) -> Option<RestakingRegistry::RestakingRegistryErrors> {
+        match self {
+            PendingTransactionError::TransportError(transport_error) => {
+                transport_error.decode_error()
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<PendingTransactionError> for RestakingRegistryError<PendingTransactionError> {
+    fn from(value: PendingTransactionError) -> Self {
+        match value.decode_error() {
+            Some(error) => RestakingRegistryError::Revert(error),
+            _ => RestakingRegistryError::Inner(value),
+        }
+    }
+}

--- a/crates/contracts/src/registry.rs
+++ b/crates/contracts/src/registry.rs
@@ -1,11 +1,9 @@
 use alloy::{
-    providers::PendingTransactionError,
-    rpc::json_rpc::ErrorPayload,
-    sol,
-    transports::{RpcError, TransportError},
+    providers::PendingTransactionError, rpc::json_rpc::ErrorPayload, sol,
+    transports::TransportError,
 };
 
-use crate::error::DecodeError;
+use crate::{error::DecodeError, impl_decode_error};
 
 sol!(
     #[allow(missing_docs)]
@@ -130,6 +128,8 @@ impl std::fmt::Display for RestakingRegistry::RestakingRegistryErrors {
     }
 }
 
+impl_decode_error!(RestakingRegistry::RestakingRegistryErrors);
+
 #[derive(Debug, thiserror::Error)]
 pub enum RestakingRegistryError<E: std::fmt::Debug> {
     #[error("RestakingRegistry error: {0}")]
@@ -155,17 +155,6 @@ impl From<ErrorPayload> for RestakingRegistryError<ErrorPayload> {
     }
 }
 
-impl DecodeError<TransportError> for RestakingRegistry::RestakingRegistryErrors {
-    fn decode_error(error: &TransportError) -> Option<RestakingRegistry::RestakingRegistryErrors> {
-        match error {
-            RpcError::ErrorResp(error) => {
-                error.as_decoded_error::<RestakingRegistry::RestakingRegistryErrors>(true)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl From<TransportError> for RestakingRegistryError<TransportError> {
     fn from(value: TransportError) -> Self {
         match RestakingRegistry::RestakingRegistryErrors::decode_error(&value) {
@@ -175,37 +164,11 @@ impl From<TransportError> for RestakingRegistryError<TransportError> {
     }
 }
 
-impl DecodeError<alloy::contract::Error> for RestakingRegistry::RestakingRegistryErrors {
-    fn decode_error(
-        error: &alloy::contract::Error,
-    ) -> Option<RestakingRegistry::RestakingRegistryErrors> {
-        match error {
-            alloy::contract::Error::TransportError(transport_error) => {
-                RestakingRegistry::RestakingRegistryErrors::decode_error(transport_error)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl From<alloy::contract::Error> for RestakingRegistryError<alloy::contract::Error> {
     fn from(value: alloy::contract::Error) -> Self {
         match RestakingRegistry::RestakingRegistryErrors::decode_error(&value) {
             Some(error) => RestakingRegistryError::Revert(error),
             _ => RestakingRegistryError::Inner(value),
-        }
-    }
-}
-
-impl DecodeError<PendingTransactionError> for RestakingRegistry::RestakingRegistryErrors {
-    fn decode_error(
-        error: &PendingTransactionError,
-    ) -> Option<RestakingRegistry::RestakingRegistryErrors> {
-        match error {
-            PendingTransactionError::TransportError(transport_error) => {
-                RestakingRegistry::RestakingRegistryErrors::decode_error(transport_error)
-            }
-            _ => None,
         }
     }
 }

--- a/crates/contracts/src/vault.rs
+++ b/crates/contracts/src/vault.rs
@@ -1,4 +1,9 @@
-use alloy::sol;
+use alloy::{
+    providers::PendingTransactionError, rpc::json_rpc::ErrorPayload, sol,
+    transports::TransportError,
+};
+
+use crate::error::DecodeError;
 
 sol!(
     #[allow(clippy::too_many_arguments)]
@@ -7,3 +12,259 @@ sol!(
     Vault,
     "abi/Vault.json",
 );
+
+impl std::fmt::Debug for Vault::VaultErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Vault::VaultErrors::AllowanceOverflow(_) => {
+                write!(f, "AllowanceOverflow")
+            }
+            Vault::VaultErrors::AllowanceUnderflow(_) => {
+                write!(f, "AllowanceUnderflow")
+            }
+            Vault::VaultErrors::AlreadyInitialized(_) => {
+                write!(f, "AlreadyInitialized")
+            }
+            Vault::VaultErrors::AttemptedPauseWhileUnpausing(_) => {
+                write!(f, "AttemptedPauseWhileUnpausing")
+            }
+            Vault::VaultErrors::AttemptedUnpauseWhilePausing(_) => {
+                write!(f, "AttemptedUnpauseWhilePausing")
+            }
+            Vault::VaultErrors::DepositMoreThanMax(_) => {
+                write!(f, "DepositMoreThanMax")
+            }
+            Vault::VaultErrors::EnforcedPause(_) => {
+                write!(f, "EnforcedPause")
+            }
+            Vault::VaultErrors::EnforcedPauseFunction(_) => {
+                write!(f, "EnforcedPauseFunction")
+            }
+            Vault::VaultErrors::InsufficientAllowance(_) => {
+                write!(f, "InsufficientAllowance")
+            }
+            Vault::VaultErrors::InsufficientBalance(_) => {
+                write!(f, "InsufficientBalance")
+            }
+            Vault::VaultErrors::InvalidInitialization(_) => {
+                write!(f, "InvalidInitialization")
+            }
+            Vault::VaultErrors::InvalidPermit(_) => {
+                write!(f, "InvalidPermit")
+            }
+            Vault::VaultErrors::MinWithdrawDelayNotPassed(_) => {
+                write!(f, "MinWithdrawDelayNotPassed")
+            }
+            Vault::VaultErrors::MintMoreThanMax(_) => {
+                write!(f, "MintMoreThanMax")
+            }
+            Vault::VaultErrors::NewOwnerIsZeroAddress(_) => {
+                write!(f, "NewOwnerIsZeroAddress")
+            }
+            Vault::VaultErrors::NoHandoverRequest(_) => {
+                write!(f, "NoHandoverRequest")
+            }
+            Vault::VaultErrors::NotEnoughShares(_) => {
+                write!(f, "NotEnoughShares")
+            }
+            Vault::VaultErrors::NotImplemented(_) => {
+                write!(f, "NotImplemented")
+            }
+            Vault::VaultErrors::NotInitializing(_) => {
+                write!(f, "NotInitializing")
+            }
+            Vault::VaultErrors::PermitExpired(_) => {
+                write!(f, "PermitExpired")
+            }
+            Vault::VaultErrors::RedeemMoreThanMax(_) => {
+                write!(f, "RedeemMoreThanMax")
+            }
+            Vault::VaultErrors::Reentrancy(_) => {
+                write!(f, "Reentrancy")
+            }
+            Vault::VaultErrors::TotalSupplyOverflow(_) => {
+                write!(f, "TotalSupplyOverflow")
+            }
+            Vault::VaultErrors::Unauthorized(_) => {
+                write!(f, "Unauthorized")
+            }
+            Vault::VaultErrors::WithdrawMoreThanMax(_) => {
+                write!(f, "WithdrawMoreThanMax")
+            }
+            Vault::VaultErrors::WithdrawalNotFound(_) => {
+                write!(f, "WithdrawalNotFound")
+            }
+            Vault::VaultErrors::ZeroAddress(_) => {
+                write!(f, "ZeroAddress")
+            }
+            Vault::VaultErrors::ZeroAmount(_) => {
+                write!(f, "ZeroAmount")
+            }
+            Vault::VaultErrors::ZeroShares(_) => {
+                write!(f, "ZeroShares")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Vault::VaultErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Vault::VaultErrors::AllowanceOverflow(_) => {
+                write!(f, "Allowance overflow")
+            }
+            Vault::VaultErrors::AllowanceUnderflow(_) => {
+                write!(f, "Allowance underflow")
+            }
+            Vault::VaultErrors::AlreadyInitialized(_) => {
+                write!(f, "Already initialized")
+            }
+            Vault::VaultErrors::AttemptedPauseWhileUnpausing(_) => {
+                write!(f, "Attempted pause while unpausing")
+            }
+            Vault::VaultErrors::AttemptedUnpauseWhilePausing(_) => {
+                write!(f, "Attempted unpause while pausing")
+            }
+            Vault::VaultErrors::DepositMoreThanMax(_) => {
+                write!(f, "Deposit more than max")
+            }
+            Vault::VaultErrors::EnforcedPause(_) => {
+                write!(f, "Enforced pause")
+            }
+            Vault::VaultErrors::EnforcedPauseFunction(_) => {
+                write!(f, "Enforced pause function")
+            }
+            Vault::VaultErrors::InsufficientAllowance(_) => {
+                write!(f, "Insufficient allowance")
+            }
+            Vault::VaultErrors::InsufficientBalance(_) => {
+                write!(f, "Insufficient balance")
+            }
+            Vault::VaultErrors::InvalidInitialization(_) => {
+                write!(f, "Invalid initialization")
+            }
+            Vault::VaultErrors::InvalidPermit(_) => {
+                write!(f, "Invalid permit")
+            }
+            Vault::VaultErrors::MinWithdrawDelayNotPassed(_) => {
+                write!(f, "Min withdraw delay not passed")
+            }
+            Vault::VaultErrors::MintMoreThanMax(_) => {
+                write!(f, "Mint more than max")
+            }
+            Vault::VaultErrors::NewOwnerIsZeroAddress(_) => {
+                write!(f, "New owner is zero address")
+            }
+            Vault::VaultErrors::NoHandoverRequest(_) => {
+                write!(f, "No handover request")
+            }
+            Vault::VaultErrors::NotEnoughShares(_) => {
+                write!(f, "Not enough shares")
+            }
+            Vault::VaultErrors::NotImplemented(_) => {
+                write!(f, "Not implemented")
+            }
+            Vault::VaultErrors::NotInitializing(_) => {
+                write!(f, "Not initializing")
+            }
+            Vault::VaultErrors::PermitExpired(_) => {
+                write!(f, "Permit expired")
+            }
+            Vault::VaultErrors::RedeemMoreThanMax(_) => {
+                write!(f, "Redeem more than max")
+            }
+            Vault::VaultErrors::Reentrancy(_) => {
+                write!(f, "Reentrancy")
+            }
+            Vault::VaultErrors::TotalSupplyOverflow(_) => {
+                write!(f, "Total supply overflow")
+            }
+            Vault::VaultErrors::Unauthorized(_) => {
+                write!(f, "Unauthorized")
+            }
+            Vault::VaultErrors::WithdrawMoreThanMax(_) => {
+                write!(f, "Withdraw more than max")
+            }
+            Vault::VaultErrors::WithdrawalNotFound(_) => {
+                write!(f, "Withdrawal not found")
+            }
+            Vault::VaultErrors::ZeroAddress(_) => {
+                write!(f, "Zero address")
+            }
+            Vault::VaultErrors::ZeroAmount(_) => {
+                write!(f, "Zero amount")
+            }
+            Vault::VaultErrors::ZeroShares(_) => {
+                write!(f, "Zero shares")
+            }
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error<E: std::fmt::Debug> {
+    #[error("Vault error: {0}")]
+    VaultError(Vault::VaultErrors),
+    #[error(transparent)]
+    Inner(E),
+}
+
+impl DecodeError<Vault::VaultErrors> for ErrorPayload {
+    fn decode_error(&self) -> Option<Vault::VaultErrors> {
+        self.as_decoded_error::<Vault::VaultErrors>(true)
+    }
+}
+
+impl DecodeError<Vault::VaultErrors> for TransportError {
+    fn decode_error(&self) -> Option<Vault::VaultErrors> {
+        match self {
+            alloy::transports::RpcError::ErrorResp(error) => error.decode_error(),
+            _ => None,
+        }
+    }
+}
+
+impl From<ErrorPayload> for Error<ErrorPayload> {
+    fn from(err: ErrorPayload) -> Self {
+        match err.decode_error() {
+            Some(err) => Error::VaultError(err),
+            None => Error::Inner(err),
+        }
+    }
+}
+
+impl DecodeError<Vault::VaultErrors> for alloy::contract::Error {
+    fn decode_error(&self) -> Option<Vault::VaultErrors> {
+        match self {
+            alloy::contract::Error::TransportError(error) => error.decode_error(),
+            _ => None,
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for Error<alloy::contract::Error> {
+    fn from(err: alloy::contract::Error) -> Self {
+        match err.decode_error() {
+            Some(err) => Error::VaultError(err),
+            None => Error::Inner(err),
+        }
+    }
+}
+
+impl DecodeError<Vault::VaultErrors> for PendingTransactionError {
+    fn decode_error(&self) -> Option<Vault::VaultErrors> {
+        match self {
+            PendingTransactionError::TransportError(error) => error.decode_error(),
+            _ => None,
+        }
+    }
+}
+
+impl From<PendingTransactionError> for Error<PendingTransactionError> {
+    fn from(err: PendingTransactionError) -> Self {
+        match err.decode_error() {
+            Some(err) => Error::VaultError(err),
+            None => Error::Inner(err),
+        }
+    }
+}

--- a/crates/contracts/src/vault.rs
+++ b/crates/contracts/src/vault.rs
@@ -3,7 +3,7 @@ use alloy::{
     transports::TransportError,
 };
 
-use crate::{erc20::library::SafeTransferLib, error::DecodeError};
+use crate::{erc20::library::SafeTransferLib, error::DecodeError, impl_decode_error};
 
 sol!(
     #[allow(clippy::too_many_arguments)]
@@ -201,6 +201,8 @@ impl std::fmt::Display for Vault::VaultErrors {
     }
 }
 
+impl_decode_error!(Vault::VaultErrors);
+
 #[derive(thiserror::Error, Debug)]
 pub enum VaultError<E: std::fmt::Debug> {
     #[error("Vault error: {0}")]
@@ -211,12 +213,6 @@ pub enum VaultError<E: std::fmt::Debug> {
     Inner(E),
 }
 
-impl DecodeError<ErrorPayload> for Vault::VaultErrors {
-    fn decode_error(error: &ErrorPayload) -> Option<Vault::VaultErrors> {
-        error.as_decoded_error::<Vault::VaultErrors>(true)
-    }
-}
-
 impl From<ErrorPayload> for VaultError<ErrorPayload> {
     fn from(error: ErrorPayload) -> Self {
         match Vault::VaultErrors::decode_error(&error) {
@@ -225,17 +221,6 @@ impl From<ErrorPayload> for VaultError<ErrorPayload> {
                 Some(error) => VaultError::SafeTransferLib(error),
                 None => VaultError::Inner(error),
             },
-        }
-    }
-}
-
-impl DecodeError<TransportError> for Vault::VaultErrors {
-    fn decode_error(error: &TransportError) -> Option<Vault::VaultErrors> {
-        match error {
-            alloy::transports::RpcError::ErrorResp(error) => {
-                Vault::VaultErrors::decode_error(error)
-            }
-            _ => None,
         }
     }
 }
@@ -252,17 +237,6 @@ impl From<TransportError> for VaultError<TransportError> {
     }
 }
 
-impl DecodeError<alloy::contract::Error> for Vault::VaultErrors {
-    fn decode_error(error: &alloy::contract::Error) -> Option<Vault::VaultErrors> {
-        match error {
-            alloy::contract::Error::TransportError(error) => {
-                Vault::VaultErrors::decode_error(error)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl From<alloy::contract::Error> for VaultError<alloy::contract::Error> {
     fn from(error: alloy::contract::Error) -> Self {
         match Vault::VaultErrors::decode_error(&error) {
@@ -271,17 +245,6 @@ impl From<alloy::contract::Error> for VaultError<alloy::contract::Error> {
                 Some(error) => VaultError::SafeTransferLib(error),
                 None => VaultError::Inner(error),
             },
-        }
-    }
-}
-
-impl DecodeError<PendingTransactionError> for Vault::VaultErrors {
-    fn decode_error(error: &PendingTransactionError) -> Option<Vault::VaultErrors> {
-        match error {
-            PendingTransactionError::TransportError(error) => {
-                Vault::VaultErrors::decode_error(error)
-            }
-            _ => None,
         }
     }
 }

--- a/crates/contracts/src/vault.rs
+++ b/crates/contracts/src/vault.rs
@@ -202,9 +202,9 @@ impl std::fmt::Display for Vault::VaultErrors {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error<E: std::fmt::Debug> {
+pub enum VaultError<E: std::fmt::Debug> {
     #[error("Vault error: {0}")]
-    VaultError(Vault::VaultErrors),
+    Revert(Vault::VaultErrors),
     #[error(transparent)]
     Inner(E),
 }
@@ -224,11 +224,11 @@ impl DecodeError<Vault::VaultErrors> for TransportError {
     }
 }
 
-impl From<ErrorPayload> for Error<ErrorPayload> {
+impl From<ErrorPayload> for VaultError<ErrorPayload> {
     fn from(err: ErrorPayload) -> Self {
         match err.decode_error() {
-            Some(err) => Error::VaultError(err),
-            None => Error::Inner(err),
+            Some(err) => VaultError::Revert(err),
+            None => VaultError::Inner(err),
         }
     }
 }
@@ -242,11 +242,11 @@ impl DecodeError<Vault::VaultErrors> for alloy::contract::Error {
     }
 }
 
-impl From<alloy::contract::Error> for Error<alloy::contract::Error> {
+impl From<alloy::contract::Error> for VaultError<alloy::contract::Error> {
     fn from(err: alloy::contract::Error) -> Self {
         match err.decode_error() {
-            Some(err) => Error::VaultError(err),
-            None => Error::Inner(err),
+            Some(err) => VaultError::Revert(err),
+            None => VaultError::Inner(err),
         }
     }
 }
@@ -260,11 +260,11 @@ impl DecodeError<Vault::VaultErrors> for PendingTransactionError {
     }
 }
 
-impl From<PendingTransactionError> for Error<PendingTransactionError> {
+impl From<PendingTransactionError> for VaultError<PendingTransactionError> {
     fn from(err: PendingTransactionError) -> Self {
         match err.decode_error() {
-            Some(err) => Error::VaultError(err),
-            None => Error::Inner(err),
+            Some(err) => VaultError::Revert(err),
+            None => VaultError::Inner(err),
         }
     }
 }


### PR DESCRIPTION
Use wrapper types to make error decoding more convenient using alloy's `send` and `send_transaction` methods